### PR TITLE
Implement growable file allocation and management in nanots

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python tools/amalgamate/amalgamate.py)",
+      "PowerShell(cargo --version 2>&1)",
+      "PowerShell(rustc --version 2>&1)",
+      "PowerShell(python --version 2>&1)",
+      "Bash(grep -E \"\\\\.\\(c|cpp|so|pyd|o\\)$\")"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A lightweight, high-performance, embedded (like sqlite) time-series database opt
 - **Memory-mapped storage**: Lock free storage data structure on memory mapped file allows for maximum throughput.
 - **Configurable durability**: Trade-off between performance and data safety with configurable block sizes
 - **Crash recovery**: Automatic detection and recovery from unexpected shutdowns
-- **Preallocated storage**: Preallocated storage files avoid filesystem fragmentation and administration hassles. In auto-recyle mode you always have the latest data.
+- **Two storage modes**: *Preallocated* (fixed-size files, no surprises on disk usage — ideal for surveillance/embedded) or *Growable* (file extends on demand using BoltDB-style doubling, capped at 1 GiB per grow).
 - **Multiple streams**: Store different data streams in the same database file
 - **Iterator interface**: Efficient navigation with bidirectional iteration and timestamp-based seeking
 - **Cross Platform**: Currently works on Linux, Windows and MacOS.
@@ -60,8 +60,14 @@ Each block contains:
 ```cpp
 #include "nanots.h"
 
-// Create database with 1MB blocks, 16 total blocks
+// Option A: Preallocated — 1MB blocks, 16 total blocks. File is the full
+// size up front; never grows. Best for fixed-budget storage (surveillance,
+// embedded).
 nanots_writer::allocate("video.nts", 1024*1024, 16);
+
+// Option B: Growable — file starts at just the 64KB header and extends on
+// demand. Pass 0 for max_blocks to grow until disk-full.
+nanots_writer::allocate_growable("video.nts", 1024*1024, 0);
 
 // Open the db in auto recycle mode (once full, new data will re-use the oldest blocks).
 nanots_writer db("video.nts", true);
@@ -129,6 +135,33 @@ nanots_writer::allocate("data.nts", 16 * 1024 * 1024, 8);  // 16MB blocks
 // What I use for h.264 video streams
 nanots_writer::allocate("data.nts", 10 * 1024 * 1024, 100); // 100 10mb blocks
 ```
+
+### Preallocated vs. Growable
+
+NanoTS supports two storage modes, both using the same on-disk block layout:
+
+```cpp
+// Preallocated: file is fully allocated up front and never changes size.
+// Predictable disk usage, no fragmentation, fast steady-state writes.
+nanots_writer::allocate("data.nts", 1024 * 1024, 100);
+
+// Growable: file starts as just a 64KB header and is extended on demand.
+// File size grows BoltDB-style (doubles each time, capped at 1 GiB per
+// grow event). Pass max_blocks > 0 to bound the maximum file size.
+nanots_writer::allocate_growable("data.nts", 1024 * 1024, /*max_blocks=*/0);
+```
+
+Pick **preallocated** when you care about predictable disk usage (surveillance
+systems, embedded devices, anything where surprise disk-full failures are
+unacceptable). Pick **growable** when you want the file to fit the data —
+useful for general time-series workloads where you don't know the data
+volume up front.
+
+Growable mode can be combined with `auto_reclaim`: grow until the cap (or
+disk-full) is reached, then start recycling the oldest blocks.
+
+Internally, growable files are marked by `n_blocks == 0` in the file header.
+Existing preallocated files are unaffected and continue to open as before.
 
 ## Use Cases
 

--- a/amalgamated_src/nanots.cpp
+++ b/amalgamated_src/nanots.cpp
@@ -1176,26 +1176,41 @@ static std::optional<block> _db_reclaim_oldest_used_block(
   return block{block_id, std::stoll(row["idx"].value())};
 }
 
-static std::optional<block> _db_get_block(const nts_sqlite_conn& conn,
-                                          bool auto_reclaim) {
+static std::optional<block> _db_get_free_block(const nts_sqlite_conn& conn) {
   auto result =
       conn.exec("SELECT id, idx FROM blocks WHERE status = 'free' LIMIT 1;");
 
-  if (!result.empty()) {
-    auto row = result.front();
-    int64_t block_id = std::stoll(row["id"].value());
+  if (result.empty())
+    return std::nullopt;
 
-    auto stmt =
-        conn.prepare("UPDATE blocks SET status = 'reserved' WHERE id = ?");
-    stmt.bind(1, block_id).exec_no_result();
+  auto row = result.front();
+  int64_t block_id = std::stoll(row["id"].value());
 
-    return block{block_id, std::stoll(row["idx"].value())};
+  auto stmt =
+      conn.prepare("UPDATE blocks SET status = 'reserved' WHERE id = ?");
+  stmt.bind(1, block_id).exec_no_result();
+
+  return block{block_id, std::stoll(row["idx"].value())};
+}
+
+static std::optional<block> _db_get_block(const nts_sqlite_conn& conn,
+                                          bool auto_reclaim,
+                                          nanots_writer* writer_for_growth) {
+  // 1. Try to reuse a previously-freed block.
+  if (auto b = _db_get_free_block(conn)) return b;
+
+  // 2. In growable mode (and not yet at the cap), extend the file.
+  //    Growth is preferred over reclaim: the user opted into growable
+  //    because they'd rather use more disk than lose old data.
+  if (writer_for_growth && writer_for_growth->is_growable()) {
+    if (auto b = writer_for_growth->_grow_blocks(conn)) return b;
   }
 
+  // 3. Fall back to recycling the oldest finalized block.
   if (auto_reclaim)
     return _db_reclaim_oldest_used_block(conn);
-  else
-    throw nanots_exception(NANOTS_EC_NO_FREE_BLOCKS, "Unable to get free block.", __FILE__, __LINE__);
+
+  throw nanots_exception(NANOTS_EC_NO_FREE_BLOCKS, "Unable to get free block.", __FILE__, __LINE__);
 }
 
 static std::optional<segment> _db_create_segment(const nts_sqlite_conn& conn,
@@ -1334,6 +1349,12 @@ nanots_writer::nanots_writer(const std::string& file_name, bool auto_reclaim)
       _file_header_p((uint8_t*)_file_header_mm.map()),
       _block_size(*(uint32_t*)_file_header_p),
       _n_blocks(*(uint32_t*)(_file_header_p + sizeof(uint32_t))),
+      // max_blocks lives at offset 8. For legacy preallocated files this byte
+      // range was zeroed by fallocate (Linux/macOS) or left at whatever
+      // SetEndOfFile produced (Windows). Only consulted in growable mode, and
+      // new allocate() always writes 0 here, so legacy preallocated files are
+      // unaffected.
+      _max_blocks(*(uint32_t*)(_file_header_p + 8)),
       _auto_reclaim(auto_reclaim) {
   if (_block_size < 4096 || _block_size > 1024 * 1024 * 1024)
     throw nanots_exception(NANOTS_EC_INVALID_BLOCK_SIZE, "Invalid block size in file header.", __FILE__, __LINE__);
@@ -1342,6 +1363,57 @@ nanots_writer::nanots_writer(const std::string& file_name, bool auto_reclaim)
   nts_sqlite_conn db(db_name, true, true);
   _upgrade_db(db);
   _validate_blocks(_file_name);
+}
+
+std::optional<block> nanots_writer::_grow_blocks(const nts_sqlite_conn& conn) {
+  // Current physical block count comes from sqlite (authoritative).
+  auto count_rows = conn.exec("SELECT COUNT(*) AS c FROM blocks;");
+  int64_t current_count = std::stoll(count_rows.front()["c"].value());
+
+  // Honor the cap.
+  if (_max_blocks > 0 && current_count >= _max_blocks)
+    return std::nullopt;
+
+  // BoltDB-style: double the current count, capped at 1 GiB per grow.
+  // First-ever grow allocates exactly 1 block.
+  const int64_t cap_bytes = 1024LL * 1024LL * 1024LL;
+  int64_t cap_blocks = std::max<int64_t>(1, cap_bytes / _block_size);
+
+  int64_t to_add = (current_count == 0)
+                       ? 1
+                       : std::min<int64_t>(current_count, cap_blocks);
+
+  // Don't exceed _max_blocks if one is set.
+  if (_max_blocks > 0)
+    to_add = std::min<int64_t>(to_add, int64_t(_max_blocks) - current_count);
+
+  if (to_add <= 0)
+    return std::nullopt;
+
+  // Extend the file. fallocate is idempotent on size — if a previous grow
+  // partially succeeded (file extended but sqlite rolled back), we just
+  // re-extend to the same or larger size, no harm done.
+  uint64_t new_size = FILE_HEADER_BLOCK_SIZE +
+                      static_cast<uint64_t>(current_count + to_add) * _block_size;
+
+  if (fallocate(_file, new_size) < 0)
+    throw nanots_exception(NANOTS_EC_UNABLE_TO_ALLOCATE_FILE,
+                           "Unable to grow file.", __FILE__, __LINE__);
+
+  _file_size = new_size;
+
+  // Insert new block rows. First one is 'reserved' (the caller's slot);
+  // the rest are 'free' for future writes.
+  auto stmt = conn.prepare("INSERT INTO blocks (idx, status) VALUES (?, ?)");
+  int64_t first_new_idx = current_count;
+  for (int64_t i = 0; i < to_add; i++) {
+    int64_t idx = current_count + i;
+    stmt.reset();
+    stmt.bind(1, idx).bind(2, std::string(i == 0 ? "reserved" : "free")).exec_no_result();
+  }
+
+  int64_t first_new_id = std::stoll(conn.last_insert_id()) - (to_add - 1);
+  return block{first_new_id, first_new_idx};
 }
 
 write_context nanots_writer::create_write_context(const std::string& stream_tag,
@@ -1390,7 +1462,7 @@ void nanots_writer::write(write_context& wctx,
     nts_sqlite_conn conn(_database_name(_file_name), true, true);
 
     nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-      auto block = _db_get_block(conn, _auto_reclaim);
+      auto block = _db_get_block(conn, _auto_reclaim, this);
       if (!block)
         throw nanots_exception(NANOTS_EC_NO_FREE_BLOCKS, "Unable to get free block.", __FILE__, __LINE__);
 
@@ -1516,6 +1588,25 @@ void nanots_writer::free_blocks(const std::string& file_name,
   });
 }
 
+void nanots_writer::allocate_growable(const std::string& file_name,
+                                      uint32_t block_size,
+                                      uint32_t max_blocks) {
+  // Growable mode is signalled by n_blocks == 0 in the file header.
+  // The optional max_blocks cap is stored at offset 8.
+  allocate(file_name, block_size, 0);
+
+  if (max_blocks > 0) {
+    auto f = nts_file::open(file_name, "r+");
+    nts_memory_map mm(
+        filenum(f), 0, 4096,
+        nts_memory_map::NMM_PROT_READ | nts_memory_map::NMM_PROT_WRITE,
+        nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED);
+    uint8_t* p = (uint8_t*)mm.map();
+    *(uint32_t*)(p + 8) = max_blocks;
+    mm.flush(mm.map(), 12);
+  }
+}
+
 void nanots_writer::allocate(const std::string& file_name,
                              uint32_t block_size,
                              uint32_t n_blocks) {
@@ -1524,6 +1615,8 @@ void nanots_writer::allocate(const std::string& file_name,
   // multiple of 65536 then block start and end on 64k boundaries.
   block_size = _round_to_64k_boundary(block_size);
 
+  // n_blocks == 0 ⇒ growable mode: file starts at just the header and grows
+  // on demand. Otherwise pre-allocate the full file up front.
   uint64_t file_size = FILE_HEADER_BLOCK_SIZE + static_cast<uint64_t>(n_blocks) * block_size;
 
   {
@@ -1548,8 +1641,11 @@ void nanots_writer::allocate(const std::string& file_name,
     p += sizeof(uint32_t);
     *(uint32_t*)p = n_blocks;
     p += sizeof(uint32_t);
+    // offset 8: max_blocks cap for growable mode (0 = unbounded). Always
+    // zero here; allocate_growable() overwrites it if a cap was requested.
+    *(uint32_t*)p = 0;
 
-    mm.flush(mm.map(), 8);
+    mm.flush(mm.map(), 12);
   }
 
   auto db_name = _database_name(file_name);
@@ -2375,6 +2471,24 @@ nanots_ec_t nanots_writer_allocate_file(const char* file_name, uint32_t block_si
   }
   if(ec != NANOTS_EC_OK) {
     fprintf(stderr,"Error in nanots_writer_allocate_file: %d\n", ec);
+  }
+  return ec;
+}
+
+nanots_ec_t nanots_writer_allocate_growable_file(const char* file_name, uint32_t block_size, uint32_t max_blocks) {
+  nanots_ec_t ec = nanots_ec_t::NANOTS_EC_OK;
+  try {
+    nanots_writer::allocate_growable(std::string(file_name), block_size, max_blocks);
+  } catch (const nanots_exception& e) {
+    ec = e.get_ec();
+  } catch (const std::exception& e) {
+    fprintf(stderr,"Exception in nanots_writer_allocate_growable_file: %s\n", e.what());
+    ec = NANOTS_EC_UNKNOWN;
+  } catch (...) {
+    ec = NANOTS_EC_UNKNOWN;
+  }
+  if(ec != NANOTS_EC_OK) {
+    fprintf(stderr,"Error in nanots_writer_allocate_growable_file: %d\n", ec);
   }
   return ec;
 }

--- a/amalgamated_src/nanots.h
+++ b/amalgamated_src/nanots.h
@@ -162,9 +162,6 @@ void nts_sqlite_transaction(const nts_sqlite_conn& db, bool immediate, T t) {
   try {
     t(db);
     db.exec("COMMIT");
-  } catch (const std::exception& ex) {
-    db.exec("ROLLBACK");
-    throw ex;
   } catch (...) {
     db.exec("ROLLBACK");
     throw;
@@ -504,18 +501,38 @@ class NANOTS_API nanots_writer {
                           int64_t start_timestamp,
                           int64_t end_timestamp);
 
+  // Preallocated: fixed-size file with n_blocks slots, never grows.
+  // Pass n_blocks == 0 to create a growable file (see allocate_growable).
   static void allocate(const std::string& file_name,
                        uint32_t block_size,
                        uint32_t n_blocks);
 
+  // Growable: file starts at just the header and extends on demand.
+  // max_blocks == 0 means unbounded (grow until disk is full).
+  static void allocate_growable(const std::string& file_name,
+                                uint32_t block_size,
+                                uint32_t max_blocks = 0);
+
+  bool is_growable() const { return _n_blocks == 0; }
+
+  // Grow the file by some number of blocks (BoltDB-style: doubles up to a
+  // 1 GiB-per-grow cap, then linear). Caller must already hold a sqlite
+  // IMMEDIATE transaction. Returns the first new block (status='reserved');
+  // any extras are inserted as 'free'. Returns nullopt if max_blocks cap
+  // is already reached. Public only so _db_get_block can call it; treat as
+  // internal.
+  std::optional<block> _grow_blocks(const nts_sqlite_conn& conn);
+
  private:
+
   std::string _file_name;
   uint64_t _file_size;
   nts_file _file;
   nts_memory_map _file_header_mm;
   uint8_t* _file_header_p;
   uint32_t _block_size;
-  uint32_t _n_blocks;
+  uint32_t _n_blocks;       // 0 == growable mode (sentinel)
+  uint32_t _max_blocks;     // growable cap; 0 == unbounded; ignored if !growable
   bool _auto_reclaim;
   std::set<std::string> _active_stream_tags;
 };
@@ -686,6 +703,8 @@ typedef void (*nanots_read_callback_t)(const uint8_t* data,
                                        void* user_data);
 
 NANOTS_API nanots_ec_t nanots_writer_allocate_file(const char* file_name, uint32_t block_size, uint32_t n_blocks);
+
+NANOTS_API nanots_ec_t nanots_writer_allocate_growable_file(const char* file_name, uint32_t block_size, uint32_t max_blocks);
 
 // writer
 NANOTS_API nanots_writer_t nanots_writer_create(const char* file_name, int auto_reclaim);

--- a/bindings/nanots-go/examples/growable/main.go
+++ b/bindings/nanots-go/examples/growable/main.go
@@ -1,0 +1,71 @@
+// Demonstrates growable storage mode.
+//
+// In growable mode the file starts at just the 64KB header and is extended
+// on demand using a BoltDB-style doubling strategy. We print the file size
+// after each batch of writes so you can see it grow.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/nanots/nanots-go"
+)
+
+func main() {
+	tmpDir, err := os.MkdirTemp("", "nanots-growable-")
+	if err != nil {
+		log.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	dbPath := filepath.Join(tmpDir, "growable.nts")
+
+	// Use 64KB blocks so the file size jumps are easy to see.
+	const blockSize = uint32(64 * 1024)
+
+	// max_blocks=0 means "grow until the disk is full." Pass a positive
+	// value to bound the maximum file size.
+	if err := nanots.AllocateGrowableFile(dbPath, blockSize, 0); err != nil {
+		log.Fatalf("AllocateGrowableFile: %v", err)
+	}
+
+	printSize := func(label string) {
+		st, _ := os.Stat(dbPath)
+		fmt.Printf("  file size %s: %6d bytes\n", label, st.Size())
+	}
+
+	fmt.Println("=== Growable mode ===")
+	printSize("after allocate")
+
+	writer, err := nanots.NewWriter(dbPath, false)
+	if err != nil {
+		log.Fatalf("NewWriter: %v", err)
+	}
+	defer writer.Close()
+
+	ctx, err := writer.CreateWriteContext("samples", "growable demo")
+	if err != nil {
+		log.Fatalf("CreateWriteContext: %v", err)
+	}
+	defer ctx.Close()
+
+	// Each frame is half a block, so most writes force a new block, which
+	// means most writes trigger a growth event during the doubling phase.
+	payload := make([]byte, blockSize/2)
+	for i := 0; i < len(payload); i++ {
+		payload[i] = byte(i)
+	}
+
+	for i := 1; i <= 8; i++ {
+		if err := writer.Write(ctx, payload, int64(i*1000), 0); err != nil {
+			log.Fatalf("Write %d: %v", i, err)
+		}
+		printSize(fmt.Sprintf("after write %d", i))
+	}
+
+	fmt.Println("\nFile grew on demand — no preallocation, no surprises.")
+}

--- a/bindings/nanots-go/nanots.go
+++ b/bindings/nanots-go/nanots.go
@@ -95,12 +95,28 @@ func newError(code ErrorCode) error {
 	return &Error{Code: code, Message: msg}
 }
 
-// AllocateFile creates a new nanots database file with the specified block size and number of blocks
+// AllocateFile creates a new fixed-size nanots database file.
+//
+// The file is pre-allocated to hold exactly nBlocks blocks and will never
+// grow. For an on-demand-growing file, use AllocateGrowableFile.
 func AllocateFile(fileName string, blockSize, nBlocks uint32) error {
 	cFileName := C.CString(fileName)
 	defer C.free(unsafe.Pointer(cFileName))
 
 	ec := C.nanots_writer_allocate_file(cFileName, C.uint32_t(blockSize), C.uint32_t(nBlocks))
+	return newError(ErrorCode(ec))
+}
+
+// AllocateGrowableFile creates a new growable nanots database file.
+//
+// The file starts at just the 64KB header and is extended on demand using a
+// BoltDB-style doubling strategy (capped at 1 GiB per grow). Pass maxBlocks=0
+// for unbounded growth (grow until the disk is full).
+func AllocateGrowableFile(fileName string, blockSize, maxBlocks uint32) error {
+	cFileName := C.CString(fileName)
+	defer C.free(unsafe.Pointer(cFileName))
+
+	ec := C.nanots_writer_allocate_growable_file(cFileName, C.uint32_t(blockSize), C.uint32_t(maxBlocks))
 	return newError(ErrorCode(ec))
 }
 

--- a/bindings/nanots-rs/examples/growable_usage.rs
+++ b/bindings/nanots-rs/examples/growable_usage.rs
@@ -1,0 +1,54 @@
+// Demonstrates growable storage mode.
+//
+// In growable mode the file starts at just the 64KB header and is extended
+// on demand using a BoltDB-style doubling strategy. We print the file size
+// after each batch of writes so you can see it grow.
+
+use nanots_rs::Writer;
+use std::fs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path = "growable_example.nts";
+
+    // Use 64KB blocks so the file size jumps are easy to see.
+    let block_size: u32 = 64 * 1024;
+
+    // max_blocks = 0 means "grow until the disk is full." Pass a positive
+    // value to bound the maximum file size.
+    Writer::allocate_growable_file(path, block_size, 0)?;
+
+    let print_size = |label: &str| {
+        let sz = fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+        println!("  file size {:<18}: {:>6} bytes", label, sz);
+    };
+
+    println!("=== Growable mode ===");
+    print_size("after allocate");
+
+    // Inner scope so writer and context drop (flushing sqlite metadata)
+    // before we try to delete the files.
+    {
+        let writer = Writer::new(path, false)?;
+        let ctx = writer.create_context("samples", "growable demo")?;
+
+        // Each frame is half a block, so most writes force a new block,
+        // which means most writes trigger a growth event during the
+        // doubling phase.
+        let payload: Vec<u8> = (0..(block_size / 2) as usize).map(|i| i as u8).collect();
+
+        for i in 1..=8i64 {
+            writer.write(&ctx, &payload, i * 1000, 0)?;
+            print_size(&format!("after write {}", i));
+        }
+    }
+
+    println!("\nFile grew on demand — no preallocation, no surprises.");
+
+    let db = path.replace(".nts", ".db");
+    fs::remove_file(path).ok();
+    fs::remove_file(&db).ok();
+    fs::remove_file(format!("{}-shm", db)).ok();
+    fs::remove_file(format!("{}-wal", db)).ok();
+
+    Ok(())
+}

--- a/bindings/nanots-rs/src/lib.rs
+++ b/bindings/nanots-rs/src/lib.rs
@@ -148,6 +148,12 @@ extern "C" {
         n_blocks: u32,
     ) -> u32;
 
+    fn nanots_writer_allocate_growable_file(
+        file_name: *const c_char,
+        block_size: u32,
+        max_blocks: u32,
+    ) -> u32;
+
     fn nanots_writer_create(file_name: *const c_char, auto_reclaim: c_int) -> WriterPtr;
     fn nanots_writer_destroy(writer: WriterPtr);
     fn nanots_writer_create_context(
@@ -303,11 +309,38 @@ impl Writer {
         }
     }
 
-    /// Allocate a new database file
+    /// Allocate a new fixed-size database file.
+    ///
+    /// The file is pre-allocated to hold exactly `n_blocks` blocks and will
+    /// never grow. For an on-demand-growing file, use
+    /// [`allocate_growable_file`](Self::allocate_growable_file).
     pub fn allocate_file(file_name: &str, block_size: u32, n_blocks: u32) -> Result<()> {
         let c_file_name = CString::new(file_name).map_err(|_| ErrorCode::InvalidArgument)?;
         let result =
             unsafe { nanots_writer_allocate_file(c_file_name.as_ptr(), block_size, n_blocks) };
+        let error_code = ErrorCode::from_c(result);
+        if error_code == ErrorCode::Ok {
+            Ok(())
+        } else {
+            Err(error_code)
+        }
+    }
+
+    /// Allocate a new growable database file.
+    ///
+    /// The file starts at just the 64KB header and is extended on demand
+    /// using a BoltDB-style doubling strategy (capped at 1 GiB per grow).
+    /// Pass `max_blocks = 0` for unbounded growth (grow until the disk is
+    /// full).
+    pub fn allocate_growable_file(
+        file_name: &str,
+        block_size: u32,
+        max_blocks: u32,
+    ) -> Result<()> {
+        let c_file_name = CString::new(file_name).map_err(|_| ErrorCode::InvalidArgument)?;
+        let result = unsafe {
+            nanots_writer_allocate_growable_file(c_file_name.as_ptr(), block_size, max_blocks)
+        };
         let error_code = ErrorCode::from_c(result);
         if error_code == ErrorCode::Ok {
             Ok(())

--- a/bindings/nanots_python/nanots.pyx
+++ b/bindings/nanots_python/nanots.pyx
@@ -67,6 +67,9 @@ cdef extern from "nanots.h":
     nanots_ec_t nanots_writer_allocate_file(const char* file_name,
                                             uint32_t block_size,
                                             uint32_t n_blocks)
+    nanots_ec_t nanots_writer_allocate_growable_file(const char* file_name,
+                                                     uint32_t block_size,
+                                                     uint32_t max_blocks)
     
     nanots_reader_t nanots_reader_create(const char* file_name)
     void nanots_reader_destroy(nanots_reader_t reader)
@@ -187,9 +190,26 @@ cdef void _check_result(nanots_ec_t result):
 
 # Utility function to create database files
 def allocate_file(str filename, uint32_t block_size, uint32_t n_blocks):
-    """Allocate a new nanots database file."""
+    """Allocate a new fixed-size nanots database file.
+
+    The file is pre-allocated to hold exactly ``n_blocks`` blocks and will
+    never grow. Use ``allocate_growable_file`` for an on-demand-growing file.
+    """
     cdef bytes filename_bytes = filename.encode('utf-8')
     cdef nanots_ec_t result = nanots_writer_allocate_file(filename_bytes, block_size, n_blocks)
+    _check_result(result)
+
+def allocate_growable_file(str filename, uint32_t block_size, uint32_t max_blocks=0):
+    """Allocate a new growable nanots database file.
+
+    The file starts at just the 64KB header and is extended on demand using
+    a BoltDB-style doubling strategy (capped at 1 GiB per grow). Set
+    ``max_blocks`` to bound the maximum file size; 0 (the default) means
+    grow until the disk is full.
+    """
+    cdef bytes filename_bytes = filename.encode('utf-8')
+    cdef nanots_ec_t result = nanots_writer_allocate_growable_file(
+        filename_bytes, block_size, max_blocks)
     _check_result(result)
 
 # Write Context wrapper

--- a/bindings/nanots_python/tests/basics/test_growable.py
+++ b/bindings/nanots_python/tests/basics/test_growable.py
@@ -1,0 +1,57 @@
+"""Demonstrates growable storage mode.
+
+In growable mode the file starts at just the 64KB header and is extended
+on demand using a BoltDB-style doubling strategy. This script prints the
+file size after each write so you can watch the file grow.
+"""
+
+import os
+import tempfile
+import nanots
+
+
+def growable_example():
+    with tempfile.NamedTemporaryFile(delete=False, suffix='.nts') as tmp:
+        db_file = tmp.name
+
+    try:
+        block_size = 64 * 1024  # 64KB blocks so size jumps are easy to see
+
+        # max_blocks=0 means "grow until the disk is full." Pass a positive
+        # value to bound the maximum file size.
+        nanots.allocate_growable_file(db_file, block_size, 0)
+
+        print("=== Growable mode ===")
+        print(f"  file size after allocate: {os.path.getsize(db_file):6d} bytes")
+
+        writer = nanots.Writer(db_file, auto_reclaim=False)
+        ctx = writer.create_context("samples", "growable demo")
+
+        # Each frame is half a block, so most writes force a new block, which
+        # means most writes trigger a growth event during the doubling phase.
+        payload = bytes(i & 0xff for i in range(block_size // 2))
+
+        for i in range(1, 9):
+            writer.write(ctx, payload, i * 1000, 0)
+            print(f"  file size after write {i}: {os.path.getsize(db_file):6d} bytes")
+
+        # Drop the writer/ctx explicitly so their destructors run (flushing
+        # sqlite metadata) before we try to delete the files in `finally`.
+        del ctx
+        del writer
+
+        print("\nFile grew on demand — no preallocation, no surprises.")
+
+    finally:
+        # Clean up the .nts file and its sqlite sidecar.
+        for path in (db_file, db_file.replace('.nts', '.db'),
+                     db_file.replace('.nts', '.db') + '-shm',
+                     db_file.replace('.nts', '.db') + '-wal'):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    growable_example()

--- a/nanots.cpp
+++ b/nanots.cpp
@@ -241,26 +241,41 @@ static std::optional<block> _db_reclaim_oldest_used_block(
   return block{block_id, std::stoll(row["idx"].value())};
 }
 
-static std::optional<block> _db_get_block(const nts_sqlite_conn& conn,
-                                          bool auto_reclaim) {
+static std::optional<block> _db_get_free_block(const nts_sqlite_conn& conn) {
   auto result =
       conn.exec("SELECT id, idx FROM blocks WHERE status = 'free' LIMIT 1;");
 
-  if (!result.empty()) {
-    auto row = result.front();
-    int64_t block_id = std::stoll(row["id"].value());
+  if (result.empty())
+    return std::nullopt;
 
-    auto stmt =
-        conn.prepare("UPDATE blocks SET status = 'reserved' WHERE id = ?");
-    stmt.bind(1, block_id).exec_no_result();
+  auto row = result.front();
+  int64_t block_id = std::stoll(row["id"].value());
 
-    return block{block_id, std::stoll(row["idx"].value())};
+  auto stmt =
+      conn.prepare("UPDATE blocks SET status = 'reserved' WHERE id = ?");
+  stmt.bind(1, block_id).exec_no_result();
+
+  return block{block_id, std::stoll(row["idx"].value())};
+}
+
+static std::optional<block> _db_get_block(const nts_sqlite_conn& conn,
+                                          bool auto_reclaim,
+                                          nanots_writer* writer_for_growth) {
+  // 1. Try to reuse a previously-freed block.
+  if (auto b = _db_get_free_block(conn)) return b;
+
+  // 2. In growable mode (and not yet at the cap), extend the file.
+  //    Growth is preferred over reclaim: the user opted into growable
+  //    because they'd rather use more disk than lose old data.
+  if (writer_for_growth && writer_for_growth->is_growable()) {
+    if (auto b = writer_for_growth->_grow_blocks(conn)) return b;
   }
 
+  // 3. Fall back to recycling the oldest finalized block.
   if (auto_reclaim)
     return _db_reclaim_oldest_used_block(conn);
-  else
-    throw nanots_exception(NANOTS_EC_NO_FREE_BLOCKS, "Unable to get free block.", __FILE__, __LINE__);
+
+  throw nanots_exception(NANOTS_EC_NO_FREE_BLOCKS, "Unable to get free block.", __FILE__, __LINE__);
 }
 
 static std::optional<segment> _db_create_segment(const nts_sqlite_conn& conn,
@@ -399,6 +414,12 @@ nanots_writer::nanots_writer(const std::string& file_name, bool auto_reclaim)
       _file_header_p((uint8_t*)_file_header_mm.map()),
       _block_size(*(uint32_t*)_file_header_p),
       _n_blocks(*(uint32_t*)(_file_header_p + sizeof(uint32_t))),
+      // max_blocks lives at offset 8. For legacy preallocated files this byte
+      // range was zeroed by fallocate (Linux/macOS) or left at whatever
+      // SetEndOfFile produced (Windows). Only consulted in growable mode, and
+      // new allocate() always writes 0 here, so legacy preallocated files are
+      // unaffected.
+      _max_blocks(*(uint32_t*)(_file_header_p + 8)),
       _auto_reclaim(auto_reclaim) {
   if (_block_size < 4096 || _block_size > 1024 * 1024 * 1024)
     throw nanots_exception(NANOTS_EC_INVALID_BLOCK_SIZE, "Invalid block size in file header.", __FILE__, __LINE__);
@@ -407,6 +428,57 @@ nanots_writer::nanots_writer(const std::string& file_name, bool auto_reclaim)
   nts_sqlite_conn db(db_name, true, true);
   _upgrade_db(db);
   _validate_blocks(_file_name);
+}
+
+std::optional<block> nanots_writer::_grow_blocks(const nts_sqlite_conn& conn) {
+  // Current physical block count comes from sqlite (authoritative).
+  auto count_rows = conn.exec("SELECT COUNT(*) AS c FROM blocks;");
+  int64_t current_count = std::stoll(count_rows.front()["c"].value());
+
+  // Honor the cap.
+  if (_max_blocks > 0 && current_count >= _max_blocks)
+    return std::nullopt;
+
+  // BoltDB-style: double the current count, capped at 1 GiB per grow.
+  // First-ever grow allocates exactly 1 block.
+  const int64_t cap_bytes = 1024LL * 1024LL * 1024LL;
+  int64_t cap_blocks = std::max<int64_t>(1, cap_bytes / _block_size);
+
+  int64_t to_add = (current_count == 0)
+                       ? 1
+                       : std::min<int64_t>(current_count, cap_blocks);
+
+  // Don't exceed _max_blocks if one is set.
+  if (_max_blocks > 0)
+    to_add = std::min<int64_t>(to_add, int64_t(_max_blocks) - current_count);
+
+  if (to_add <= 0)
+    return std::nullopt;
+
+  // Extend the file. fallocate is idempotent on size — if a previous grow
+  // partially succeeded (file extended but sqlite rolled back), we just
+  // re-extend to the same or larger size, no harm done.
+  uint64_t new_size = FILE_HEADER_BLOCK_SIZE +
+                      static_cast<uint64_t>(current_count + to_add) * _block_size;
+
+  if (fallocate(_file, new_size) < 0)
+    throw nanots_exception(NANOTS_EC_UNABLE_TO_ALLOCATE_FILE,
+                           "Unable to grow file.", __FILE__, __LINE__);
+
+  _file_size = new_size;
+
+  // Insert new block rows. First one is 'reserved' (the caller's slot);
+  // the rest are 'free' for future writes.
+  auto stmt = conn.prepare("INSERT INTO blocks (idx, status) VALUES (?, ?)");
+  int64_t first_new_idx = current_count;
+  for (int64_t i = 0; i < to_add; i++) {
+    int64_t idx = current_count + i;
+    stmt.reset();
+    stmt.bind(1, idx).bind(2, std::string(i == 0 ? "reserved" : "free")).exec_no_result();
+  }
+
+  int64_t first_new_id = std::stoll(conn.last_insert_id()) - (to_add - 1);
+  return block{first_new_id, first_new_idx};
 }
 
 write_context nanots_writer::create_write_context(const std::string& stream_tag,
@@ -455,7 +527,7 @@ void nanots_writer::write(write_context& wctx,
     nts_sqlite_conn conn(_database_name(_file_name), true, true);
 
     nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-      auto block = _db_get_block(conn, _auto_reclaim);
+      auto block = _db_get_block(conn, _auto_reclaim, this);
       if (!block)
         throw nanots_exception(NANOTS_EC_NO_FREE_BLOCKS, "Unable to get free block.", __FILE__, __LINE__);
 
@@ -581,6 +653,25 @@ void nanots_writer::free_blocks(const std::string& file_name,
   });
 }
 
+void nanots_writer::allocate_growable(const std::string& file_name,
+                                      uint32_t block_size,
+                                      uint32_t max_blocks) {
+  // Growable mode is signalled by n_blocks == 0 in the file header.
+  // The optional max_blocks cap is stored at offset 8.
+  allocate(file_name, block_size, 0);
+
+  if (max_blocks > 0) {
+    auto f = nts_file::open(file_name, "r+");
+    nts_memory_map mm(
+        filenum(f), 0, 4096,
+        nts_memory_map::NMM_PROT_READ | nts_memory_map::NMM_PROT_WRITE,
+        nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED);
+    uint8_t* p = (uint8_t*)mm.map();
+    *(uint32_t*)(p + 8) = max_blocks;
+    mm.flush(mm.map(), 12);
+  }
+}
+
 void nanots_writer::allocate(const std::string& file_name,
                              uint32_t block_size,
                              uint32_t n_blocks) {
@@ -589,6 +680,8 @@ void nanots_writer::allocate(const std::string& file_name,
   // multiple of 65536 then block start and end on 64k boundaries.
   block_size = _round_to_64k_boundary(block_size);
 
+  // n_blocks == 0 ⇒ growable mode: file starts at just the header and grows
+  // on demand. Otherwise pre-allocate the full file up front.
   uint64_t file_size = FILE_HEADER_BLOCK_SIZE + static_cast<uint64_t>(n_blocks) * block_size;
 
   {
@@ -613,8 +706,11 @@ void nanots_writer::allocate(const std::string& file_name,
     p += sizeof(uint32_t);
     *(uint32_t*)p = n_blocks;
     p += sizeof(uint32_t);
+    // offset 8: max_blocks cap for growable mode (0 = unbounded). Always
+    // zero here; allocate_growable() overwrites it if a cap was requested.
+    *(uint32_t*)p = 0;
 
-    mm.flush(mm.map(), 8);
+    mm.flush(mm.map(), 12);
   }
 
   auto db_name = _database_name(file_name);
@@ -1440,6 +1536,24 @@ nanots_ec_t nanots_writer_allocate_file(const char* file_name, uint32_t block_si
   }
   if(ec != NANOTS_EC_OK) {
     fprintf(stderr,"Error in nanots_writer_allocate_file: %d\n", ec);
+  }
+  return ec;
+}
+
+nanots_ec_t nanots_writer_allocate_growable_file(const char* file_name, uint32_t block_size, uint32_t max_blocks) {
+  nanots_ec_t ec = nanots_ec_t::NANOTS_EC_OK;
+  try {
+    nanots_writer::allocate_growable(std::string(file_name), block_size, max_blocks);
+  } catch (const nanots_exception& e) {
+    ec = e.get_ec();
+  } catch (const std::exception& e) {
+    fprintf(stderr,"Exception in nanots_writer_allocate_growable_file: %s\n", e.what());
+    ec = NANOTS_EC_UNKNOWN;
+  } catch (...) {
+    ec = NANOTS_EC_UNKNOWN;
+  }
+  if(ec != NANOTS_EC_OK) {
+    fprintf(stderr,"Error in nanots_writer_allocate_growable_file: %d\n", ec);
   }
   return ec;
 }

--- a/nanots.h
+++ b/nanots.h
@@ -133,18 +133,38 @@ class NANOTS_API nanots_writer {
                           int64_t start_timestamp,
                           int64_t end_timestamp);
 
+  // Preallocated: fixed-size file with n_blocks slots, never grows.
+  // Pass n_blocks == 0 to create a growable file (see allocate_growable).
   static void allocate(const std::string& file_name,
                        uint32_t block_size,
                        uint32_t n_blocks);
 
+  // Growable: file starts at just the header and extends on demand.
+  // max_blocks == 0 means unbounded (grow until disk is full).
+  static void allocate_growable(const std::string& file_name,
+                                uint32_t block_size,
+                                uint32_t max_blocks = 0);
+
+  bool is_growable() const { return _n_blocks == 0; }
+
+  // Grow the file by some number of blocks (BoltDB-style: doubles up to a
+  // 1 GiB-per-grow cap, then linear). Caller must already hold a sqlite
+  // IMMEDIATE transaction. Returns the first new block (status='reserved');
+  // any extras are inserted as 'free'. Returns nullopt if max_blocks cap
+  // is already reached. Public only so _db_get_block can call it; treat as
+  // internal.
+  std::optional<block> _grow_blocks(const nts_sqlite_conn& conn);
+
  private:
+
   std::string _file_name;
   uint64_t _file_size;
   nts_file _file;
   nts_memory_map _file_header_mm;
   uint8_t* _file_header_p;
   uint32_t _block_size;
-  uint32_t _n_blocks;
+  uint32_t _n_blocks;       // 0 == growable mode (sentinel)
+  uint32_t _max_blocks;     // growable cap; 0 == unbounded; ignored if !growable
   bool _auto_reclaim;
   std::set<std::string> _active_stream_tags;
 };
@@ -315,6 +335,8 @@ typedef void (*nanots_read_callback_t)(const uint8_t* data,
                                        void* user_data);
 
 NANOTS_API nanots_ec_t nanots_writer_allocate_file(const char* file_name, uint32_t block_size, uint32_t n_blocks);
+
+NANOTS_API nanots_ec_t nanots_writer_allocate_growable_file(const char* file_name, uint32_t block_size, uint32_t max_blocks);
 
 // writer
 NANOTS_API nanots_writer_t nanots_writer_create(const char* file_name, int auto_reclaim);

--- a/ut/include/test_nanots.h
+++ b/ut/include/test_nanots.h
@@ -35,6 +35,9 @@ class test_nanots : public test_fixture {
   TEST(test_nanots::test_nanots_iterator_block_transition_flag_search);
   TEST(test_nanots::test_nanots_iterator_performance_benchmark);
   TEST(test_nanots::test_nanots_iterator_seek_end);
+  TEST(test_nanots::test_nanots_growable_basic);
+  TEST(test_nanots::test_nanots_growable_doubling);
+  TEST(test_nanots::test_nanots_growable_max_cap);
   RTF_FIXTURE_END();
 
   virtual ~test_nanots() throw() {}
@@ -74,4 +77,7 @@ class test_nanots : public test_fixture {
   void test_nanots_iterator_block_transition_flag_search();
   void test_nanots_iterator_performance_benchmark();
   void test_nanots_iterator_seek_end();
+  void test_nanots_growable_basic();
+  void test_nanots_growable_doubling();
+  void test_nanots_growable_max_cap();
 };

--- a/ut/source/test_nanots.cpp
+++ b/ut/source/test_nanots.cpp
@@ -21,6 +21,18 @@ static void _whack_files() {
     rtf_remove_file("nanots_test_4mb.nts");
   if (rtf_file_exists("nanots_test_2048_4k_blocks.nts"))
     rtf_remove_file("nanots_test_2048_4k_blocks.nts");
+
+  for (const char* name :
+       {"nanots_growable_basic", "nanots_growable_doubling", "nanots_growable_cap"}) {
+    std::string nts = std::string(name) + ".nts";
+    std::string db  = std::string(name) + ".db";
+    std::string shm = db + "-shm";
+    std::string wal = db + "-wal";
+    if (rtf_file_exists(nts.c_str())) rtf_remove_file(nts.c_str());
+    if (rtf_file_exists(db.c_str())) rtf_remove_file(db.c_str());
+    if (rtf_file_exists(shm.c_str())) rtf_remove_file(shm.c_str());
+    if (rtf_file_exists(wal.c_str())) rtf_remove_file(wal.c_str());
+  }
 }
 
 void test_nanots::setup() {
@@ -2029,4 +2041,134 @@ void test_nanots::test_nanots_iterator_seek_end() {
     RTF_ASSERT(!iter.seek_end());
     RTF_ASSERT(!iter.valid());
   }
+}
+
+// File starts empty (header only). Writing frames must extend the file and
+// read-back must work exactly like a preallocated file.
+void test_nanots::test_nanots_growable_basic() {
+  const char* nts = "nanots_growable_basic.nts";
+  const uint32_t block_size = 64 * 1024;
+
+  nanots_writer::allocate_growable(nts, block_size, 0);
+
+  // File should start at just the header (64KB), no blocks yet.
+  RTF_ASSERT(file_size(nts) == 64 * 1024);
+
+  {
+    nanots_writer db(nts, false);
+    RTF_ASSERT(db.is_growable());
+
+    auto wctx = db.create_write_context("grow_stream", "growable test");
+
+    // Write frames small enough that several fit in one block, large enough
+    // to force several blocks total. Block payload area is roughly
+    // (block_size - header - index_overhead). Write ~10 blocks' worth.
+    const size_t frame_size = 4 * 1024;
+    std::vector<uint8_t> data(frame_size, 0x5A);
+
+    for (int i = 0; i < 200; i++) {
+      db.write(wctx, data.data(), frame_size, 1000 + i * 100, (uint8_t)(i & 0xff));
+    }
+  }
+
+  // File should have grown beyond the bare header.
+  uint64_t after_size = file_size(nts);
+  printf("growable_basic: file size after writes = %llu bytes\n",
+         (unsigned long long)after_size);
+  RTF_ASSERT(after_size > 64 * 1024);
+  // Must still be header + integer multiple of block_size.
+  RTF_ASSERT(((after_size - 64 * 1024) % block_size) == 0);
+
+  // Reopen and read everything back.
+  {
+    nanots_iterator iter(nts, "grow_stream");
+    int n = 0;
+    int64_t last_ts = 0;
+    while (iter.valid()) {
+      RTF_ASSERT(iter->size == 4 * 1024);
+      RTF_ASSERT(iter->timestamp > last_ts);
+      last_ts = iter->timestamp;
+      n++;
+      ++iter;
+    }
+    RTF_ASSERT(n == 200);
+  }
+}
+
+// Verify the doubling growth pattern: file size after each grow event should
+// be roughly 2x the previous size (until the 1 GiB-per-grow cap kicks in).
+void test_nanots::test_nanots_growable_doubling() {
+  const char* nts = "nanots_growable_doubling.nts";
+  const uint32_t block_size = 64 * 1024;
+
+  nanots_writer::allocate_growable(nts, block_size, 0);
+
+  nanots_writer db(nts, false);
+  auto wctx = db.create_write_context("doubling", "");
+
+  // Each frame is just under block-payload size so each frame ends up in
+  // its own block. That makes every write a grow-or-recycle event.
+  const size_t frame_size = block_size / 2;
+  std::vector<uint8_t> data(frame_size, 0xCD);
+
+  std::vector<uint64_t> sizes;
+  sizes.push_back(file_size(nts));
+  for (int i = 0; i < 8; i++) {
+    db.write(wctx, data.data(), frame_size, 1000 + i, 0);
+    sizes.push_back(file_size(nts));
+  }
+
+  printf("growable_doubling: sizes (bytes): ");
+  for (auto s : sizes) printf("%llu ", (unsigned long long)s);
+  printf("\n");
+
+  // After the first write we have 1 block. After subsequent grows we should
+  // see 2, 4, 8, ... blocks (until we stop forcing growth).
+  // Each entry should monotonically increase.
+  for (size_t i = 1; i < sizes.size(); i++) {
+    RTF_ASSERT(sizes[i] >= sizes[i - 1]);
+  }
+  // First write should have grown the file by exactly one block.
+  RTF_ASSERT(sizes[1] == sizes[0] + block_size);
+  // Second write should double (add another block, total 2).
+  RTF_ASSERT(sizes[2] == sizes[0] + 2 * block_size);
+  // Third write should double again (total 4).
+  RTF_ASSERT(sizes[3] == sizes[0] + 4 * block_size);
+}
+
+// max_blocks cap: once we hit the cap, further writes throw (no auto_reclaim).
+void test_nanots::test_nanots_growable_max_cap() {
+  const char* nts = "nanots_growable_cap.nts";
+  const uint32_t block_size = 64 * 1024;
+  const uint32_t cap = 3;
+
+  nanots_writer::allocate_growable(nts, block_size, cap);
+
+  nanots_writer db(nts, false);
+  auto wctx = db.create_write_context("capped", "");
+
+  const size_t frame_size = block_size / 2;
+  std::vector<uint8_t> data(frame_size, 0x77);
+
+  int wrote = 0;
+  bool threw = false;
+  for (int i = 0; i < 20 && !threw; i++) {
+    try {
+      db.write(wctx, data.data(), frame_size, 1000 + i, 0);
+      wrote++;
+    } catch (const nanots_exception& e) {
+      RTF_ASSERT(e.get_ec() == NANOTS_EC_NO_FREE_BLOCKS);
+      threw = true;
+    }
+  }
+
+  printf("growable_max_cap: wrote %d frames before hitting cap of %u blocks\n",
+         wrote, cap);
+  RTF_ASSERT(threw);
+  // We wrote a frame per block (each frame is block_size/2 → next write
+  // forces grow), so we should have managed exactly `cap` writes.
+  RTF_ASSERT(wrote == (int)cap);
+
+  uint64_t final_size = file_size(nts);
+  RTF_ASSERT(final_size == 64 * 1024 + (uint64_t)cap * block_size);
 }

--- a/utils.h
+++ b/utils.h
@@ -154,9 +154,6 @@ void nts_sqlite_transaction(const nts_sqlite_conn& db, bool immediate, T t) {
   try {
     t(db);
     db.exec("COMMIT");
-  } catch (const std::exception& ex) {
-    db.exec("ROLLBACK");
-    throw ex;
   } catch (...) {
     db.exec("ROLLBACK");
     throw;


### PR DESCRIPTION
- Added `allocate_growable` method to `nanots_writer` for creating growable database files.
- Introduced `_grow_blocks` method to handle dynamic block allocation in growable mode.
- Updated existing methods to support growable files, including changes to block retrieval logic.
- Enhanced error handling for block allocation failures.
- Created new examples in Go and Rust demonstrating the usage of growable files.
- Added Python bindings for growable file allocation and corresponding tests.
- Implemented unit tests to validate growable file functionality, including basic growth, doubling behavior, and maximum capacity enforcement.