### PR TITLE
Refactor nanots API for composite key support and format changes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,9 @@
       "PowerShell(cargo --version 2>&1)",
       "PowerShell(rustc --version 2>&1)",
       "PowerShell(python --version 2>&1)",
-      "Bash(grep -E \"\\\\.\\(c|cpp|so|pyd|o\\)$\")"
+      "Bash(grep -E \"\\\\.\\(c|cpp|so|pyd|o\\)$\")",
+      "PowerShell(cmake --build c:/dev/nanots/build --config Debug 2>&1)",
+      "Bash(./nanots_ut.exe)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,8 @@
       "PowerShell(python --version 2>&1)",
       "Bash(grep -E \"\\\\.\\(c|cpp|so|pyd|o\\)$\")",
       "PowerShell(cmake --build c:/dev/nanots/build --config Debug 2>&1)",
-      "Bash(./nanots_ut.exe)"
+      "Bash(./nanots_ut.exe)",
+      "Bash(python -c ' *)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -282,6 +282,31 @@ iter.find(1000, 2);
 iter.find(1000, 4);
 ```
 
+**Range queries.** All four range-style APIs — `reader.read`,
+`reader.query_contiguous_segments`, `reader.query_stream_tags`, and
+`nanots_writer::free_blocks` — take a composite window
+`(start_ts, start_sk, end_ts, end_sk)`:
+
+```cpp
+// All trades between (1000, 5) and (2000, INT64_MAX) inclusive.
+reader.read("trades", 1000, /*start_sk=*/5,
+                      2000, /*end_sk=*/INT64_MAX,
+            [&](const uint8_t* data, size_t size, uint32_t flags,
+                int64_t ts, int64_t sk,
+                int64_t block_seq, const std::string& meta) {
+                // ...
+            });
+
+// Delete blocks fully inside [(1000, MIN), (2000, MAX)] — i.e. the whole
+// timestamp window 1000..2000 regardless of sec_key.
+nanots_writer::free_blocks("data.nts", "trades",
+                           1000, NANOTS_SEC_KEY_UNSET,
+                           2000, INT64_MAX);
+```
+
+Pass `NANOTS_SEC_KEY_UNSET` for `start_sk` and `INT64_MAX` for `end_sk` to
+ignore the sec_key axis (i.e. classic timestamp-only behavior).
+
 Typical use cases: financial origin timestamps + exchange sequence ID;
 sensor readings + per-source sequence counter; any feed where the natural
 timestamp isn't unique but a stable tiebreaker is.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A lightweight, high-performance, embedded (like sqlite) time-series database opt
 - **Crash recovery**: Automatic detection and recovery from unexpected shutdowns
 - **Two storage modes**: *Preallocated* (fixed-size files, no surprises on disk usage — ideal for surveillance/embedded) or *Growable* (file extends on demand using BoltDB-style doubling, capped at 1 GiB per grow).
 - **Multiple streams**: Store different data streams in the same database file
-- **Iterator interface**: Efficient navigation with bidirectional iteration and seeking by timestamp or secondary key
-- **Optional secondary key**: Each stream can store a strictly-monotonic `int64` *secondary key* alongside the timestamp (e.g. an external sequence number or exchange-supplied trade ID) and be binary-searched on it
+- **Iterator interface**: Efficient navigation with bidirectional iteration and composite-key seeking
+- **Composite (timestamp, secondary_key) ordering**: Timestamps may repeat; an optional `int64` *secondary key* serves as the tiebreaker so the composite is strictly monotonic. Perfect for financial origin timestamps (exchange tick + sequence number) where the timestamp alone isn't unique.
 - **Cross Platform**: Currently works on Linux, Windows and MacOS.
 
 ## Performance
@@ -45,7 +45,7 @@ Block size is configurable and tunable for different applications.
 
 Each block contains:
 - **Block header**: Metadata and frame count
-- **Frame index**: Timestamp → offset mappings for fast seeks (and an optional secondary key per entry for direct seek-by-key)
+- **Frame index**: `(timestamp, secondary_key)` → offset mappings for fast composite seeks
 - **Frame data**: Variable-size frames with headers and payload
 
 ### On-Disk Format Version
@@ -88,19 +88,20 @@ nanots_writer db("video.nts", true);
 // Create write context for a stream
 auto wctx = db.create_write_context("camera_1", "stream metadata");
 
-// Every write() takes (flags, timestamp[, secondary_key]). The secondary
-// key is optional per stream and defaults to NANOTS_SEC_KEY_UNSET — i.e.
-// "this stream has no secondary key." The first write to any given stream
-// tag locks the stream as either "keyed" or "unkeyed"; subsequent writes
-// must match.
+// Every write() takes (flags, timestamp[, secondary_key]). Frames are
+// ordered by the composite (timestamp, secondary_key), which must be
+// strictly monotonic across writes. The secondary_key defaults to
+// NANOTS_SEC_KEY_UNSET — for callers that don't need a tiebreaker the
+// rule degenerates to "timestamp strictly increasing" (the classic case).
 uint8_t frame_data[] = {/* video frame bytes */};
 db.write(wctx, frame_data, sizeof(frame_data), flags, timestamp_us);
 
-// Or — for a keyed stream — pass any strictly-increasing int64 as the
-// secondary key (any value except INT64_MIN, which is the "unset" sentinel):
+// When timestamps can repeat (e.g. exchange origin timestamps that aren't
+// unique), supply a secondary key as the tiebreaker. Any int64 except
+// INT64_MIN (the "unset" sentinel) is a valid key:
 auto trade_ctx = db.create_write_context("trades", "BTC-USD ticks");
-db.write(trade_ctx, frame_data, sizeof(frame_data),
-         flags, timestamp_us, /*sequence_no=*/exchange_trade_id);
+db.write(trade_ctx, frame_data, sizeof(frame_data), flags,
+         exchange_ts, /*sequence_no=*/exchange_trade_id);
 
 ```
 
@@ -113,8 +114,8 @@ db.write(trade_ctx, frame_data, sizeof(frame_data),
 nanots_iterator iter("video.nts", "camera_1");
 
 // Iterate through all frames. Every frame exposes `timestamp`, `flags`,
-// `secondary_key` (NANOTS_SEC_KEY_UNSET on unkeyed streams), and
-// `block_sequence`.
+// `secondary_key` (NANOTS_SEC_KEY_UNSET when the writer didn't supply
+// one), and `block_sequence`.
 while (iter.valid()) {
     auto& frame = *iter;
     process_frame(frame.data, frame.size,
@@ -122,16 +123,19 @@ while (iter.valid()) {
     ++iter;
 }
 
-// Seek by timestamp (works on any stream):
+// Seek by timestamp. find(ts) lands on the FIRST frame at that timestamp
+// (smallest secondary_key, since the default is NANOTS_SEC_KEY_UNSET =
+// INT64_MIN, which is the smallest possible value).
 if (iter.find(target_timestamp)) {
     auto& frame = *iter;
     // ... process frame
 }
 
-// Or — on keyed streams — seek by the secondary key:
-if (iter.has_secondary_key() && iter.find_by_secondary_key(target_sequence)) {
+// Seek to an exact composite (timestamp + tiebreaker):
+if (iter.find(target_timestamp, target_sequence)) {
     auto& frame = *iter;
-    // frame.secondary_key >= target_sequence
+    // frame.timestamp == target_timestamp && frame.secondary_key == target_sequence
+    // (or the next-greater composite, if there's no exact match)
 }
 ```
 
@@ -212,7 +216,7 @@ Existing preallocated files are unaffected and continue to open as before.
 - Trade tick data with microsecond precision
 - Market data replay systems
 - Low-latency historical queries
-- Seek by exchange-supplied trade/sequence ID via the [secondary key](#secondary-key), independent of timestamp
+- Handle non-unique origin timestamps cleanly via the [composite (timestamp, secondary_key) ordering](#composite-timestamp-secondary_key-ordering)
 
 ## Advanced Features
 
@@ -226,51 +230,61 @@ nanots_writer db("data.nts");
 // Database is automatically validated and ready to use
 ```
 
-### Secondary Key
+### Composite (timestamp, secondary_key) Ordering
 
-Each stream can optionally store an `int64` *secondary key* alongside the
-timestamp on every frame. Typical use cases: an external monotonic sequence
-number, an exchange-supplied trade ID, or any second ordering you'd like to
-seek by without redundantly encoding it in the timestamp.
+Frames are ordered by the **composite** `(timestamp, secondary_key)` —
+that pair must be strictly greater than the previous frame's composite.
+This collapses both "timestamp strictly monotonic" (the classic case) and
+"timestamp non-unique with a tiebreaker" (origin-timestamped feeds) into
+one rule:
 
-**Stream-level choice (locked on first write).** The first write to a stream
-tag fixes that stream as either *keyed* or *unkeyed*. Mixing yields
-`NANOTS_EC_SECONDARY_KEY_MISMATCH`:
+- If the new `timestamp` is greater than the previous one, the
+  `secondary_key` can be anything.
+- If the new `timestamp` *equals* the previous one, the `secondary_key`
+  must strictly increase.
+- Smaller `timestamp` is rejected with `NANOTS_EC_NON_MONOTONIC_TIMESTAMP`.
+
+`secondary_key` defaults to `NANOTS_SEC_KEY_UNSET` (= `INT64_MIN`, the
+smallest possible `int64`). Streams that always default get the classic
+strict-timestamp-monotonic behavior at no extra cost.
 
 ```cpp
 auto wctx = db.create_write_context("trades", "BTC-USD");
 
-// First write picks the mode: this one's keyed.
-db.write(wctx, data, len, /*flags=*/0, ts1, /*sec_key=*/100);
+// Multiple frames at the same origin timestamp, disambiguated by an
+// exchange-supplied sequence number.
+db.write(wctx, data, len, /*flags=*/0, 1000, /*seq=*/1);
+db.write(wctx, data, len, 0, 1000, /*seq=*/2);
+db.write(wctx, data, len, 0, 1000, /*seq=*/3);
 
-// OK — same mode, strictly-greater key.
-db.write(wctx, data, len, 0, ts2, /*sec_key=*/101);
+// Timestamp moves forward — seq can reset (it just has to keep the
+// composite strictly increasing, which it does because ts increased).
+db.write(wctx, data, len, 0, 2000, /*seq=*/1);
 
-// Throws NANOTS_EC_SECONDARY_KEY_MISMATCH — stream is keyed.
-db.write(wctx, data, len, 0, ts3);  // omitted sec_key defaults to UNSET
-
-// Throws NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY — key must strictly increase.
-db.write(wctx, data, len, 0, ts4, /*sec_key=*/50);
+// Rejected: composite (2000, 1) is not > (2000, 1).
+db.write(wctx, data, len, 0, 2000, /*seq=*/1);
 ```
 
-For an *unkeyed* stream, just omit the `secondary_key` argument — it defaults
-to `NANOTS_SEC_KEY_UNSET` (which is `INT64_MIN`). Passing any other value —
-including `0` — counts as a real secondary key and will lock the stream as
-keyed.
-
-**Reading.** Iterators on keyed streams can binary-search by secondary key:
+**Reading.** `find(ts)` lands on the first frame at that timestamp;
+`find(ts, sk)` lands on the exact composite (or the next greater one):
 
 ```cpp
 nanots_iterator iter("data.nts", "trades");
-if (iter.has_secondary_key()) {
-    iter.find_by_secondary_key(target_sequence_number);
-    while (iter.valid()) {
-        auto& frame = *iter;
-        // frame.secondary_key is the value the writer passed
-        ++iter;
-    }
-}
+
+// First frame at timestamp 1000 (any seq).
+iter.find(1000);
+
+// Exact composite — the second tick at ts=1000, seq=2.
+iter.find(1000, 2);
+
+// Between composites — lands on the next-greater. Here (1000, 3.5)
+// rounds up to whatever follows seq=3 lexicographically.
+iter.find(1000, 4);
 ```
+
+Typical use cases: financial origin timestamps + exchange sequence ID;
+sensor readings + per-source sequence counter; any feed where the natural
+timestamp isn't unique but a stable tiebreaker is.
 
 ### Multiple Streams
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A lightweight, high-performance, embedded (like sqlite) time-series database opt
 - **Crash recovery**: Automatic detection and recovery from unexpected shutdowns
 - **Two storage modes**: *Preallocated* (fixed-size files, no surprises on disk usage — ideal for surveillance/embedded) or *Growable* (file extends on demand using BoltDB-style doubling, capped at 1 GiB per grow).
 - **Multiple streams**: Store different data streams in the same database file
-- **Iterator interface**: Efficient navigation with bidirectional iteration and timestamp-based seeking
+- **Iterator interface**: Efficient navigation with bidirectional iteration and seeking by timestamp or secondary key
+- **Optional secondary key**: Each stream can store a strictly-monotonic `int64` *secondary key* alongside the timestamp (e.g. an external sequence number or exchange-supplied trade ID) and be binary-searched on it
 - **Cross Platform**: Currently works on Linux, Windows and MacOS.
 
 ## Performance
@@ -24,7 +25,7 @@ NanoTS is designed for high-throughput, low-latency applications:
 - **113,000+ writes/second per stream** sustained on SSD
 - **3,300+ writes/second** on spinning disk
 - **Sub-microsecond reads** via memory mapping
-- **Efficient seeks** using binary search on timestamps
+- **Efficient seeks** using binary search on timestamps (or on the optional secondary key)
 
 Benchmarks are tracked in a dedicated repo: [nanots_bench](https://github.com/dicroce/nanots_bench). See [RESULTS.md](https://github.com/dicroce/nanots_bench/blob/main/RESULTS.md) for current numbers.
 
@@ -44,8 +45,20 @@ Block size is configurable and tunable for different applications.
 
 Each block contains:
 - **Block header**: Metadata and frame count
-- **Frame index**: Timestamp → offset mappings for fast seeks
+- **Frame index**: Timestamp → offset mappings for fast seeks (and an optional secondary key per entry for direct seek-by-key)
 - **Frame data**: Variable-size frames with headers and payload
+
+### On-Disk Format Version
+
+The current on-disk format is **v2**. Every nanots file begins with the
+4-byte magic `"NTS\0"` at offset 0, followed by `uint16 format_version`
+(currently `2`) and `uint16 header_size`. The header also reserves
+`uint32 flags` and `uint64 feature_bits` for future format-extension knobs,
+so adding new capabilities should not require breaking the format again.
+
+**v2 is not backwards-compatible with v1.** v1 files cannot be opened by a
+v2 build — there is no migration tool. Migrate by re-writing data into a
+freshly-allocated v2 file.
 
 ### Durability Guarantees
 
@@ -75,9 +88,19 @@ nanots_writer db("video.nts", true);
 // Create write context for a stream
 auto wctx = db.create_write_context("camera_1", "stream metadata");
 
-// Write frames
+// Every write() takes (flags, timestamp[, secondary_key]). The secondary
+// key is optional per stream and defaults to NANOTS_SEC_KEY_UNSET — i.e.
+// "this stream has no secondary key." The first write to any given stream
+// tag locks the stream as either "keyed" or "unkeyed"; subsequent writes
+// must match.
 uint8_t frame_data[] = {/* video frame bytes */};
-db.write(wctx, frame_data, sizeof(frame_data), timestamp_us, flags);
+db.write(wctx, frame_data, sizeof(frame_data), flags, timestamp_us);
+
+// Or — for a keyed stream — pass any strictly-increasing int64 as the
+// secondary key (any value except INT64_MIN, which is the "unset" sentinel):
+auto trade_ctx = db.create_write_context("trades", "BTC-USD ticks");
+db.write(trade_ctx, frame_data, sizeof(frame_data),
+         flags, timestamp_us, /*sequence_no=*/exchange_trade_id);
 
 ```
 
@@ -89,18 +112,26 @@ db.write(wctx, frame_data, sizeof(frame_data), timestamp_us, flags);
 // Create iterator for a stream
 nanots_iterator iter("video.nts", "camera_1");
 
-// Iterate through all frames
+// Iterate through all frames. Every frame exposes `timestamp`, `flags`,
+// `secondary_key` (NANOTS_SEC_KEY_UNSET on unkeyed streams), and
+// `block_sequence`.
 while (iter.valid()) {
     auto& frame = *iter;
-    process_frame(frame.data, frame.size, frame.timestamp, frame.flags);
+    process_frame(frame.data, frame.size,
+                  frame.timestamp, frame.secondary_key, frame.flags);
     ++iter;
 }
 
-// Or seek to specific timestamp
+// Seek by timestamp (works on any stream):
 if (iter.find(target_timestamp)) {
-    // Found first frame >= target_timestamp
     auto& frame = *iter;
     // ... process frame
+}
+
+// Or — on keyed streams — seek by the secondary key:
+if (iter.has_secondary_key() && iter.find_by_secondary_key(target_sequence)) {
+    auto& frame = *iter;
+    // frame.secondary_key >= target_sequence
 }
 ```
 
@@ -111,7 +142,8 @@ if (iter.find(target_timestamp)) {
 iter.find(end_timestamp);
 while (iter.valid()) {
     auto& frame = *iter;
-    process_frame(frame.data, frame.size, frame.timestamp, frame.flags);
+    process_frame(frame.data, frame.size,
+                  frame.timestamp, frame.secondary_key, frame.flags);
     --iter;  // Go to previous frame
 }
 ```
@@ -180,6 +212,7 @@ Existing preallocated files are unaffected and continue to open as before.
 - Trade tick data with microsecond precision
 - Market data replay systems
 - Low-latency historical queries
+- Seek by exchange-supplied trade/sequence ID via the [secondary key](#secondary-key), independent of timestamp
 
 ## Advanced Features
 
@@ -191,6 +224,52 @@ NanoTS automatically detects and recovers from crashes:
 // On startup, validates all blocks and recovers partial writes
 nanots_writer db("data.nts");
 // Database is automatically validated and ready to use
+```
+
+### Secondary Key
+
+Each stream can optionally store an `int64` *secondary key* alongside the
+timestamp on every frame. Typical use cases: an external monotonic sequence
+number, an exchange-supplied trade ID, or any second ordering you'd like to
+seek by without redundantly encoding it in the timestamp.
+
+**Stream-level choice (locked on first write).** The first write to a stream
+tag fixes that stream as either *keyed* or *unkeyed*. Mixing yields
+`NANOTS_EC_SECONDARY_KEY_MISMATCH`:
+
+```cpp
+auto wctx = db.create_write_context("trades", "BTC-USD");
+
+// First write picks the mode: this one's keyed.
+db.write(wctx, data, len, /*flags=*/0, ts1, /*sec_key=*/100);
+
+// OK — same mode, strictly-greater key.
+db.write(wctx, data, len, 0, ts2, /*sec_key=*/101);
+
+// Throws NANOTS_EC_SECONDARY_KEY_MISMATCH — stream is keyed.
+db.write(wctx, data, len, 0, ts3);  // omitted sec_key defaults to UNSET
+
+// Throws NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY — key must strictly increase.
+db.write(wctx, data, len, 0, ts4, /*sec_key=*/50);
+```
+
+For an *unkeyed* stream, just omit the `secondary_key` argument — it defaults
+to `NANOTS_SEC_KEY_UNSET` (which is `INT64_MIN`). Passing any other value —
+including `0` — counts as a real secondary key and will lock the stream as
+keyed.
+
+**Reading.** Iterators on keyed streams can binary-search by secondary key:
+
+```cpp
+nanots_iterator iter("data.nts", "trades");
+if (iter.has_secondary_key()) {
+    iter.find_by_secondary_key(target_sequence_number);
+    while (iter.valid()) {
+        auto& frame = *iter;
+        // frame.secondary_key is the value the writer passed
+        ++iter;
+    }
+}
 ```
 
 ### Multiple Streams

--- a/amalgamated_src/nanots.cpp
+++ b/amalgamated_src/nanots.cpp
@@ -1352,35 +1352,18 @@ static std::optional<block> _db_get_free_block(const nts_sqlite_conn& conn) {
 //  which composes _db_get_free_block / _grow_blocks / _db_reclaim_oldest_used_block
 //  with the EBR limbo/ready machinery.)
 
-// Look up whether any existing segment for this stream tag uses the secondary
-// key. Returns nullopt if no segment exists yet for this stream (caller's
-// choice will become the canonical one), or the 0/1 value otherwise.
-static std::optional<int> _db_lookup_stream_has_secondary_key(
-    const nts_sqlite_conn& conn, const std::string& stream_tag) {
-  auto stmt = conn.prepare(
-      "SELECT has_secondary_key FROM segments WHERE stream_tag = ? LIMIT 1");
-  auto rows = stmt.bind(1, stream_tag).exec();
-  if (rows.empty()) return std::nullopt;
-  return std::stoi(rows.front()["has_secondary_key"].value());
-}
-
 static std::optional<segment> _db_create_segment(const nts_sqlite_conn& conn,
                                                  const std::string& stream_tag,
-                                                 const std::string& metadata,
-                                                 bool has_secondary_key) {
+                                                 const std::string& metadata) {
   auto stmt = conn.prepare(
-      "INSERT INTO segments (stream_tag, metadata, has_secondary_key) VALUES (?, ?, ?)");
-  stmt.bind(1, stream_tag)
-      .bind(2, metadata)
-      .bind(3, has_secondary_key ? 1 : 0)
-      .exec_no_result();
+      "INSERT INTO segments (stream_tag, metadata) VALUES (?, ?)");
+  stmt.bind(1, stream_tag).bind(2, metadata).exec_no_result();
 
   segment s;
   s.id = std::stoll(conn.last_insert_id());
   s.stream_tag = stream_tag;
   s.metadata = metadata;
   s.sequence = 0;
-  s.has_secondary_key = has_secondary_key;
   return s;
 }
 
@@ -1720,55 +1703,38 @@ void nanots_writer::write(write_context& wctx,
                           uint32_t flags,
                           int64_t timestamp,
                           int64_t secondary_key) {
-  if (wctx.last_timestamp && timestamp <= wctx.last_timestamp.value())
-    throw nanots_exception(NANOTS_EC_NON_MONOTONIC_TIMESTAMP, "Timestamp is not monotonic.", __FILE__, __LINE__);
+  // Composite (timestamp, secondary_key) must be strictly greater than the
+  // previous frame's composite. When the caller doesn't pass a sec_key, the
+  // default is NANOTS_SEC_KEY_UNSET (= INT64_MIN); for a stream that never
+  // passes one this degenerates to "timestamp must strictly increase."
+  if (wctx.last_timestamp) {
+    int64_t last_ts = wctx.last_timestamp.value();
+    int64_t last_sk = wctx.last_secondary_key.value_or(NANOTS_SEC_KEY_UNSET);
+    bool composite_greater =
+        (timestamp > last_ts) ||
+        (timestamp == last_ts && secondary_key > last_sk);
+    if (!composite_greater) {
+      throw nanots_exception(
+          NANOTS_EC_NON_MONOTONIC_TIMESTAMP,
+          "Composite (timestamp, secondary_key) is not strictly greater than "
+          "the previous frame's composite.",
+          __FILE__, __LINE__);
+    }
+  }
 
   if (size >
       _block_size - (FRAME_HEADER_SIZE + INDEX_ENTRY_SIZE + BLOCK_HEADER_SIZE))
     throw nanots_exception(NANOTS_EC_ROW_SIZE_TOO_BIG, "Frame size is too large. Use a much larger block size.", __FILE__, __LINE__);
 
-  // First write to this context: lazily create (or attach to) the segment
-  // row. The very first write to a brand-new stream tag fixes the choice of
-  // whether the stream stores a secondary key on every frame.
+  // First write to this context: lazily create the segment row.
   if (!wctx.current_segment) {
-    bool wants_sec_key = (secondary_key != NANOTS_SEC_KEY_UNSET);
-
     nts_sqlite_conn conn(_database_name(_file_name), true, true);
     nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-      auto existing = _db_lookup_stream_has_secondary_key(conn, wctx.stream_tag);
-      if (existing.has_value()) {
-        bool existing_yes = (*existing != 0);
-        if (existing_yes != wants_sec_key) {
-          throw nanots_exception(
-              NANOTS_EC_SECONDARY_KEY_MISMATCH,
-              "Stream's secondary-key mode is fixed by its first write and "
-              "this write does not match.", __FILE__, __LINE__);
-        }
-      }
       wctx.current_segment = _db_create_segment(
-          conn, wctx.stream_tag, wctx.metadata, wants_sec_key);
+          conn, wctx.stream_tag, wctx.metadata);
       if (!wctx.current_segment)
         throw nanots_exception(NANOTS_EC_UNABLE_TO_CREATE_SEGMENT, "Unable to create segment.", __FILE__, __LINE__);
     });
-  } else {
-    // Subsequent writes: enforce the per-stream choice that was locked in
-    // on the first write.
-    bool stream_wants = wctx.current_segment->has_secondary_key;
-    bool this_write_provides = (secondary_key != NANOTS_SEC_KEY_UNSET);
-    if (stream_wants != this_write_provides) {
-      throw nanots_exception(
-          NANOTS_EC_SECONDARY_KEY_MISMATCH,
-          "Stream's secondary-key mode is fixed and this write does not match.",
-          __FILE__, __LINE__);
-    }
-  }
-
-  if (secondary_key != NANOTS_SEC_KEY_UNSET &&
-      wctx.last_secondary_key.has_value() &&
-      secondary_key <= wctx.last_secondary_key.value()) {
-    throw nanots_exception(NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY,
-                           "Secondary key is not monotonic.",
-                           __FILE__, __LINE__);
   }
 
   if (!wctx.current_block) {
@@ -1872,8 +1838,9 @@ void nanots_writer::write(write_context& wctx,
 #endif
 
   wctx.last_timestamp = timestamp;
-  if (secondary_key != NANOTS_SEC_KEY_UNSET)
-    wctx.last_secondary_key = secondary_key;
+  // Track the secondary key unconditionally so the composite monotonicity
+  // check on the next write has the right "last" value (including UNSET).
+  wctx.last_secondary_key = secondary_key;
 }
 
 void nanots_writer::free_blocks(const std::string& file_name,
@@ -1993,8 +1960,7 @@ void nanots_writer::allocate(const std::string& file_name,
       "CREATE TABLE segments ("
       "id INTEGER PRIMARY KEY AUTOINCREMENT, "
       "stream_tag STRING, "
-      "metadata STRING, "
-      "has_secondary_key INTEGER NOT NULL DEFAULT 0"
+      "metadata STRING"
       ");";
   db.exec(query);
 
@@ -2086,27 +2052,18 @@ nanots_reader::nanots_reader(const std::string& file_name)
   _n_blocks   = *(uint32_t*)(header_p + FILE_HEADER_N_BLOCKS_OFFSET);
 }
 
-static int _compare_index_entry_timestamp(uint8_t* index_entry_p,
-                                          uint8_t* target_timestamp_p) {
-  int64_t entry_timestamp = *(int64_t*)(index_entry_p + INDEX_ENTRY_TS_OFFSET);
-  int64_t target_timestamp = *(int64_t*)target_timestamp_p;
+// Lexicographic compare on (timestamp, secondary_key). Target is a 16-byte
+// buffer containing [target_ts (int64), target_sk (int64)]. Used for the
+// composite binary search inside a block.
+static int _compare_index_entry_composite(uint8_t* index_entry_p,
+                                          uint8_t* target_p) {
+  int64_t entry_ts = *(int64_t*)(index_entry_p + INDEX_ENTRY_TS_OFFSET);
+  int64_t target_ts = *(int64_t*)(target_p + 0);
+  if (entry_ts != target_ts) return entry_ts < target_ts ? -1 : 1;
 
-  if (entry_timestamp < target_timestamp)
-    return -1;
-  if (entry_timestamp > target_timestamp)
-    return 1;
-  return 0;
-}
-
-static int _compare_index_entry_secondary_key(uint8_t* index_entry_p,
-                                              uint8_t* target_sk_p) {
   int64_t entry_sk = *(int64_t*)(index_entry_p + INDEX_ENTRY_SECKEY_OFFSET);
-  int64_t target_sk = *(int64_t*)target_sk_p;
-
-  if (entry_sk < target_sk)
-    return -1;
-  if (entry_sk > target_sk)
-    return 1;
+  int64_t target_sk = *(int64_t*)(target_p + sizeof(int64_t));
+  if (entry_sk != target_sk) return entry_sk < target_sk ? -1 : 1;
   return 0;
 }
 
@@ -2172,9 +2129,12 @@ void nanots_reader::read(
     int64_t start_index = 0;
 
     if (need_binary_search) {
+      // Composite lower_bound at (start_timestamp, INT64_MIN) — i.e. the
+      // first frame at start_timestamp regardless of sec_key.
+      int64_t target[2] = {start_timestamp, NANOTS_SEC_KEY_UNSET};
       uint8_t* first_entry =
-          lower_bound_bytes(index_start, index_end, (uint8_t*)&start_timestamp,
-                            INDEX_ENTRY_SIZE, _compare_index_entry_timestamp);
+          lower_bound_bytes(index_start, index_end, (uint8_t*)target,
+                            INDEX_ENTRY_SIZE, _compare_index_entry_composite);
 
       start_index = (first_entry - index_start) / INDEX_ENTRY_SIZE;
       need_binary_search = false;
@@ -2325,21 +2285,6 @@ nanots_iterator::nanots_iterator(const std::string& file_name,
   reset();
 }
 
-bool nanots_iterator::has_secondary_key() {
-  if (_has_secondary_key_cache >= 0) return _has_secondary_key_cache != 0;
-  auto& db = _ensure_db_connection();
-  auto stmt = db.prepare(
-      "SELECT has_secondary_key FROM segments WHERE stream_tag = ? LIMIT 1");
-  auto rows = stmt.bind(1, _stream_tag).exec();
-  int v = 0;
-  if (!rows.empty()) {
-    auto& cell = rows.front()["has_secondary_key"];
-    if (cell.has_value()) v = std::stoi(cell.value());
-  }
-  _has_secondary_key_cache = v;
-  return v != 0;
-}
-
 nts_sqlite_conn& nanots_iterator::_ensure_db_connection() {
   if (!_db_conn.has_value()) {
     auto db_name = _database_name(_file_name);
@@ -2360,7 +2305,6 @@ block_info* nanots_iterator::_get_block_by_segment_and_sequence(int64_t segment_
     _stmt_get_block_by_id.emplace(_ensure_db_connection().prepare(
         "SELECT "
         "s.metadata as metadata, "
-        "s.has_secondary_key as has_secondary_key, "
         "sb.segment_id as segment_id, "
         "sb.sequence as block_sequence, "
         "sb.block_idx as block_idx, "
@@ -2392,8 +2336,6 @@ block_info* nanots_iterator::_get_block_by_segment_and_sequence(int64_t segment_
   block.uuid_hex = row["uuid"].value();
   block.start_timestamp = std::stoll(row["start_timestamp"].value());
   block.end_timestamp = std::stoll(row["end_timestamp"].value());
-  auto& hsk = row["has_secondary_key"];
-  block.has_secondary_key = hsk.has_value() && std::stoi(hsk.value()) != 0;
   auto& sk_start = row["start_secondary_key"];
   block.start_secondary_key = sk_start.has_value()
       ? std::stoll(sk_start.value()) : NANOTS_SEC_KEY_UNSET;
@@ -2448,35 +2390,37 @@ void nanots_iterator::_refresh_ts_index() {
   _ts_index_filled = true;
 }
 
-size_t nanots_iterator::_ts_index_find_by_sk(int64_t sk) const {
-  // Prefer a block that covers sk.
-  auto it = std::upper_bound(_ts_index.begin(), _ts_index.end(), sk,
-      [](int64_t k, const BlockRange& br) { return k < br.start_sk; });
-  if (it != _ts_index.begin()) {
-    auto prev = std::prev(it);
-    if (sk >= prev->start_sk &&
-        (prev->end_sk == 0 || sk <= prev->end_sk)) {
-      return static_cast<size_t>(std::distance(_ts_index.begin(), prev));
-    }
-  }
-  if (it != _ts_index.end()) {
-    return static_cast<size_t>(std::distance(_ts_index.begin(), it));
-  }
-  return _ts_index.size();
-}
 
-size_t nanots_iterator::_ts_index_find(int64_t ts) const {
-  // Prefer a block that covers ts.
-  auto it = std::upper_bound(_ts_index.begin(), _ts_index.end(), ts,
-      [](int64_t t, const BlockRange& br) { return t < br.start_ts; });
+size_t nanots_iterator::_ts_index_find(int64_t ts, int64_t sk) const {
+  // Composite-key search across blocks. Each block holds a sorted run of
+  // (ts, sk) tuples; the block's lex range is [(start_ts, start_sk),
+  // (end_ts, end_sk)]. We want the block whose range covers the target
+  // composite, or — failing that — the first block whose start composite
+  // is >= the target.
+  using P = std::pair<int64_t, int64_t>;
+  auto br_start = [](const BlockRange& br) { return P{br.start_ts, br.start_sk}; };
+  auto cmp_lt = [](P a, P b) {
+    return a.first != b.first ? a.first < b.first : a.second < b.second;
+  };
+
+  P target{ts, sk};
+  // First block whose start composite > target.
+  auto it = std::upper_bound(_ts_index.begin(), _ts_index.end(), target,
+      [&](P t, const BlockRange& br) { return cmp_lt(t, br_start(br)); });
+
   if (it != _ts_index.begin()) {
     auto prev = std::prev(it);
-    if (ts >= prev->start_ts &&
-        (prev->end_ts == 0 || ts <= prev->end_ts)) {
+    P prev_start = br_start(*prev);
+    bool ge_start = !cmp_lt(target, prev_start);  // target >= prev_start
+    bool open_block = (prev->end_ts == 0);
+    P prev_end{prev->end_ts, prev->end_sk};
+    bool le_end = open_block || !cmp_lt(prev_end, target);  // target <= prev_end
+    if (ge_start && le_end) {
       return static_cast<size_t>(std::distance(_ts_index.begin(), prev));
     }
   }
-  // Fallback: first block with start_ts >= ts (matches old SQL semantics).
+
+  // Fallback: first block whose start composite >= target.
   if (it != _ts_index.end()) {
     return static_cast<size_t>(std::distance(_ts_index.begin(), it));
   }
@@ -2574,7 +2518,8 @@ block_info* nanots_iterator::_get_prev_block() {
   return block;
 }
 
-block_info* nanots_iterator::_find_block_for_timestamp(int64_t timestamp) {
+block_info* nanots_iterator::_find_block_for_composite(int64_t timestamp,
+                                                       int64_t sec_key) {
   _ensure_ts_index();
 
   // Helper: given a position in _ts_index, look up its block_info. Returns
@@ -2588,7 +2533,7 @@ block_info* nanots_iterator::_find_block_for_timestamp(int64_t timestamp) {
   };
 
   // First attempt: snapshot we already have.
-  size_t pos = _ts_index_find(timestamp);
+  size_t pos = _ts_index_find(timestamp, sec_key);
   if (auto* b = try_at(pos)) return b;
 
   // Miss or stale: refresh and try once more. This catches:
@@ -2596,75 +2541,8 @@ block_info* nanots_iterator::_find_block_for_timestamp(int64_t timestamp) {
   //   (b) writer reclaimed the block we matched and the new (segment, sequence)
   //       at that idx isn't in our cache
   _refresh_ts_index();
-  pos = _ts_index_find(timestamp);
+  pos = _ts_index_find(timestamp, sec_key);
   return try_at(pos);
-}
-
-block_info* nanots_iterator::_find_block_for_secondary_key(int64_t sec_key) {
-  _ensure_ts_index();
-
-  auto try_at = [&](size_t pos) -> block_info* {
-    if (pos >= _ts_index.size()) return nullptr;
-    const auto& br = _ts_index[pos];
-    auto* b = _get_block_by_segment_and_sequence(br.segment_id, br.sequence);
-    if (b) _ts_index_pos = pos;
-    return b;
-  };
-
-  size_t pos = _ts_index_find_by_sk(sec_key);
-  if (auto* b = try_at(pos)) return b;
-
-  _refresh_ts_index();
-  pos = _ts_index_find_by_sk(sec_key);
-  return try_at(pos);
-}
-
-bool nanots_iterator::find_by_secondary_key(int64_t sec_key) {
-  nanots_op_scope _op(_slot_guard);
-
-  if (!has_secondary_key()) {
-    _valid = false;
-    return false;
-  }
-
-  block_info* block = _find_block_for_secondary_key(sec_key);
-  if (!block) {
-    _valid = false;
-    return false;
-  }
-
-  if (!_load_block_data(*block)) {
-    _valid = false;
-    return false;
-  }
-
-  _current_block_start_ts = block->start_timestamp;
-  _current_block_end_ts   = block->end_timestamp;
-  _current_segment_id     = block->segment_id;
-  _current_block_sequence = block->block_sequence;
-
-  uint8_t* index_start = block->block_p + BLOCK_HEADER_SIZE;
-  uint8_t* index_end   = index_start + (block->n_valid_indexes * INDEX_ENTRY_SIZE);
-
-  uint8_t* found_entry =
-      lower_bound_bytes(index_start, index_end, (uint8_t*)&sec_key,
-                        INDEX_ENTRY_SIZE,
-                        _compare_index_entry_secondary_key);
-
-  _current_frame_idx = (found_entry - index_start) / INDEX_ENTRY_SIZE;
-
-  if (_current_frame_idx >= block->n_valid_indexes) {
-    auto* next_block = _get_next_block();
-    if (!next_block) {
-      _valid = false;
-      return false;
-    }
-    _current_segment_id = next_block->segment_id;
-    _current_block_sequence = next_block->block_sequence;
-    _current_frame_idx = 0;
-  }
-
-  return _load_current_frame();
 }
 
 bool nanots_iterator::_load_block_data(block_info& block) {
@@ -2799,19 +2677,20 @@ nanots_iterator& nanots_iterator::operator--() {
   return *this;
 }
 
-bool nanots_iterator::find(int64_t timestamp) {
+bool nanots_iterator::find(int64_t timestamp, int64_t secondary_key) {
   nanots_op_scope _op(_slot_guard);
   block_info* block = nullptr;
 
-  // Fast path: if the target is within the already-loaded block's range, skip
-  // the SQL lookup entirely and go straight to the binary search.
+  // Fast path: if the target is within the already-loaded block's range
+  // (composite), skip the SQL lookup entirely.
   if (_valid && _current_block_end_ts != 0 &&
-      timestamp >= _current_block_start_ts && timestamp <= _current_block_end_ts) {
+      timestamp >= _current_block_start_ts &&
+      timestamp <= _current_block_end_ts) {
     block = _get_block_by_segment_and_sequence(_current_segment_id, _current_block_sequence);
   }
 
   if (!block)
-    block = _find_block_for_timestamp(timestamp);
+    block = _find_block_for_composite(timestamp, secondary_key);
 
   if (!block) {
     _valid = false;
@@ -2829,14 +2708,15 @@ bool nanots_iterator::find(int64_t timestamp) {
   _current_segment_id = block->segment_id;
   _current_block_sequence = block->block_sequence;
 
-  // Binary search within the block
+  // Composite lower_bound within the block.
   uint8_t* index_start = block->block_p + BLOCK_HEADER_SIZE;
   uint8_t* index_end =
       index_start + (block->n_valid_indexes * INDEX_ENTRY_SIZE);
 
+  int64_t target[2] = {timestamp, secondary_key};
   uint8_t* found_entry =
-      lower_bound_bytes(index_start, index_end, (uint8_t*)&timestamp,
-                        INDEX_ENTRY_SIZE, _compare_index_entry_timestamp);
+      lower_bound_bytes(index_start, index_end, (uint8_t*)target,
+                        INDEX_ENTRY_SIZE, _compare_index_entry_composite);
 
   _current_frame_idx = (found_entry - index_start) / INDEX_ENTRY_SIZE;
 
@@ -2853,32 +2733,7 @@ bool nanots_iterator::find(int64_t timestamp) {
     _current_frame_idx = 0;
   }
 
-  // Get frame info from index
-  uint8_t* index_p = block->block_p + BLOCK_HEADER_SIZE +
-                     (_current_frame_idx * INDEX_ENTRY_SIZE);
-  int64_t found_timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
-  uint64_t offset = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
-
-  // Validate frame header
-  uint32_t flags;
-  uint32_t frame_size;
-  int64_t sec_key;
-  if (!_validate_frame_header(block->block_p + offset, block->uuid, &flags,
-                              &frame_size, &sec_key)) {
-    _valid = false;
-    return false;
-  }
-
-  // Set up current frame
-  _current_frame.data = block->block_p + offset + FRAME_HEADER_SIZE;
-  _current_frame.size = frame_size;
-  _current_frame.flags = flags;
-  _current_frame.timestamp = found_timestamp;
-  _current_frame.secondary_key = sec_key;
-  _current_frame.block_sequence = block->block_sequence;
-
-  _valid = true;
-  return true;
+  return _load_current_frame();
 }
 
 void nanots_iterator::reset() {
@@ -3328,13 +3183,14 @@ nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator) {
 }
 
 nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
-                                     int64_t timestamp) {
+                                 int64_t timestamp,
+                                 int64_t secondary_key) {
   if (!iterator || !iterator->iterator) {
     return NANOTS_EC_INVALID_ARGUMENT;
   }
 
   try {
-    bool found = iterator->iterator->find(timestamp);
+    bool found = iterator->iterator->find(timestamp, secondary_key);
     return found ? NANOTS_EC_OK : NANOTS_EC_INVALID_ARGUMENT;
   } catch (const nanots_exception& e) {
     return e.get_ec();
@@ -3344,37 +3200,6 @@ nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
   } catch (...) {
     fprintf(stderr,"Exception in nanots_iterator_find\n");
     return NANOTS_EC_UNKNOWN;
-  }
-}
-
-nanots_ec_t nanots_iterator_find_by_secondary_key(nanots_iterator_t iterator,
-                                                  int64_t secondary_key) {
-  if (!iterator || !iterator->iterator) {
-    return NANOTS_EC_INVALID_ARGUMENT;
-  }
-
-  try {
-    bool found = iterator->iterator->find_by_secondary_key(secondary_key);
-    return found ? NANOTS_EC_OK : NANOTS_EC_INVALID_ARGUMENT;
-  } catch (const nanots_exception& e) {
-    return e.get_ec();
-  } catch (const std::exception& e) {
-    fprintf(stderr,"Exception in nanots_iterator_find_by_secondary_key: %s\n", e.what());
-    return NANOTS_EC_UNKNOWN;
-  } catch (...) {
-    fprintf(stderr,"Exception in nanots_iterator_find_by_secondary_key\n");
-    return NANOTS_EC_UNKNOWN;
-  }
-}
-
-int nanots_iterator_has_secondary_key(nanots_iterator_t iterator) {
-  if (!iterator || !iterator->iterator) {
-    return 0;
-  }
-  try {
-    return iterator->iterator->has_secondary_key() ? 1 : 0;
-  } catch (...) {
-    return 0;
   }
 }
 

--- a/amalgamated_src/nanots.cpp
+++ b/amalgamated_src/nanots.cpp
@@ -1846,22 +1846,35 @@ void nanots_writer::write(write_context& wctx,
 void nanots_writer::free_blocks(const std::string& file_name,
                                 const std::string& stream_tag,
                                 int64_t start_timestamp,
-                                int64_t end_timestamp) {
+                                int64_t start_secondary_key,
+                                int64_t end_timestamp,
+                                int64_t end_secondary_key) {
   auto db_name = _database_name(file_name);
   nts_sqlite_conn conn(db_name, true, true);
 
   nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-    // Find blocks that fall entirely within the deletion time range
+    // Find blocks fully contained in the composite window
+    // [(start_ts, start_sk), (end_ts, end_sk)]:
+    //   block_start >= window_start:
+    //     start_ts > ? OR (start_ts = ? AND start_sk >= ?)
+    //   block_end <= window_end:
+    //     end_ts < ? OR (end_ts = ? AND end_sk <= ?)
+    // Plus end_timestamp != 0 to skip the currently-open block.
     auto stmt = conn.prepare(
         "SELECT sb.id as segment_block_id, sb.block_id "
         "FROM segment_blocks sb "
         "JOIN segments s ON sb.segment_id = s.id "
         "WHERE s.stream_tag = ? "
-        "AND sb.start_timestamp >= ? "
-        "AND sb.end_timestamp <= ? "
+        "AND (sb.start_timestamp > ? OR "
+        "     (sb.start_timestamp = ? AND sb.start_secondary_key >= ?)) "
+        "AND (sb.end_timestamp < ? OR "
+        "     (sb.end_timestamp = ? AND sb.end_secondary_key <= ?)) "
         "AND sb.end_timestamp != 0");
     auto blocks_to_delete =
-        stmt.bind(1, stream_tag).bind(2, start_timestamp).bind(3, end_timestamp).exec();
+        stmt.bind(1, stream_tag)
+            .bind(2, start_timestamp).bind(3, start_timestamp).bind(4, start_secondary_key)
+            .bind(5, end_timestamp).bind(6, end_timestamp).bind(7, end_secondary_key)
+            .exec();
 
     for (auto& block_row : blocks_to_delete) {
       int64_t segment_block_id = std::stoll(block_row["segment_block_id"].value());
@@ -2070,7 +2083,9 @@ static int _compare_index_entry_composite(uint8_t* index_entry_p,
 void nanots_reader::read(
     const std::string& stream_tag,
     int64_t start_timestamp,
+    int64_t start_secondary_key,
     int64_t end_timestamp,
+    int64_t end_secondary_key,
     const std::function<
         void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback) {
   // EBR critical section spans the entire read(): the writer must not
@@ -2079,6 +2094,13 @@ void nanots_reader::read(
 
   nts_sqlite_conn db(_database_name(_file_name), false, true);
 
+  // Composite overlap: include a block whose lex range
+  // [(start_ts, start_sk), (end_ts, end_sk)] intersects the requested
+  // window. Two lex comparisons:
+  //   block_start <= window_end:
+  //     start_ts < ?  OR  (start_ts = ? AND start_sk <= ?)
+  //   block_end >= window_start  (or open block end_ts == 0):
+  //     end_ts = 0 OR end_ts > ? OR (end_ts = ? AND end_sk >= ?)
   auto stmt = db.prepare(
       "SELECT "
       "s.metadata as metadata, "
@@ -2090,11 +2112,16 @@ void nanots_reader::read(
       "FROM segments s "
       "JOIN segment_blocks sb ON sb.segment_id = s.id "
       "WHERE s.stream_tag = ? "
-      "AND sb.start_timestamp <= ? "
-      "AND (sb.end_timestamp >= ? OR sb.end_timestamp = 0) "
+      "AND (sb.start_timestamp < ? OR "
+      "     (sb.start_timestamp = ? AND sb.start_secondary_key <= ?)) "
+      "AND (sb.end_timestamp = 0 OR sb.end_timestamp > ? OR "
+      "     (sb.end_timestamp = ? AND sb.end_secondary_key >= ?)) "
       "ORDER BY sb.sequence ASC;");
   auto results =
-      stmt.bind(1, stream_tag).bind(2, end_timestamp).bind(3, start_timestamp).exec();
+      stmt.bind(1, stream_tag)
+          .bind(2, end_timestamp).bind(3, end_timestamp).bind(4, end_secondary_key)
+          .bind(5, start_timestamp).bind(6, start_timestamp).bind(7, start_secondary_key)
+          .exec();
 
   bool need_binary_search = true;
 
@@ -2129,9 +2156,8 @@ void nanots_reader::read(
     int64_t start_index = 0;
 
     if (need_binary_search) {
-      // Composite lower_bound at (start_timestamp, INT64_MIN) — i.e. the
-      // first frame at start_timestamp regardless of sec_key.
-      int64_t target[2] = {start_timestamp, NANOTS_SEC_KEY_UNSET};
+      // Composite lower_bound at (start_timestamp, start_secondary_key).
+      int64_t target[2] = {start_timestamp, start_secondary_key};
       uint8_t* first_entry =
           lower_bound_bytes(index_start, index_end, (uint8_t*)target,
                             INDEX_ENTRY_SIZE, _compare_index_entry_composite);
@@ -2144,10 +2170,12 @@ void nanots_reader::read(
     for (size_t i = start_index; i < n_valid_indexes; i++) {
       uint8_t* index_p = block_p + BLOCK_HEADER_SIZE + (i * INDEX_ENTRY_SIZE);
       int64_t timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+      int64_t sk_index  = *(int64_t*)(index_p + INDEX_ENTRY_SECKEY_OFFSET);
       uint64_t offset   = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
-      // Check if we've passed the end time
-      if (timestamp > end_timestamp)
+      // Check if we've passed the end composite.
+      if (timestamp > end_timestamp ||
+          (timestamp == end_timestamp && sk_index > end_secondary_key))
         return;  // All done!
 
       // Validate frame header
@@ -2167,16 +2195,27 @@ void nanots_reader::read(
   }
 }
 
-std::vector<std::string> nanots_reader::query_stream_tags(int64_t start_timestamp, int64_t end_timestamp) {
+std::vector<std::string> nanots_reader::query_stream_tags(
+    int64_t start_timestamp,
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key) {
   nts_sqlite_conn db(_database_name(_file_name), false, true);
 
+  // Composite overlap: a block contributes if its lex range overlaps the
+  // requested window. Same predicate as nanots_reader::read.
   auto stmt = db.prepare(
       "SELECT DISTINCT s.stream_tag "
       "FROM segments s "
       "JOIN segment_blocks sb ON s.id = sb.segment_id "
-      "WHERE sb.start_timestamp <= ? AND (sb.end_timestamp >= ? OR sb.end_timestamp = 0);");
+      "WHERE (sb.start_timestamp < ? OR "
+      "       (sb.start_timestamp = ? AND sb.start_secondary_key <= ?)) "
+      "AND (sb.end_timestamp = 0 OR sb.end_timestamp > ? OR "
+      "     (sb.end_timestamp = ? AND sb.end_secondary_key >= ?));");
   auto results =
-      stmt.bind(1, end_timestamp).bind(2, start_timestamp).exec();
+      stmt.bind(1, end_timestamp).bind(2, end_timestamp).bind(3, end_secondary_key)
+          .bind(4, start_timestamp).bind(5, start_timestamp).bind(6, start_secondary_key)
+          .exec();
 
   std::vector<std::string> stream_tags;
 
@@ -2190,58 +2229,84 @@ std::vector<std::string> nanots_reader::query_stream_tags(int64_t start_timestam
 std::vector<contiguous_segment> nanots_reader::query_contiguous_segments(
     const std::string& stream_tag,
     int64_t start_timestamp,
-    int64_t end_timestamp) {
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key) {
   nts_sqlite_conn db(_database_name(_file_name), false, true);
 
-  // Create a grouping key by subtracting sequence from row number
-  // Contiguous sequences will have the same group_key
-
+  // Create a grouping key by subtracting sequence from row number; within
+  // a stream blocks are composite-monotonic, so contiguous-by-sequence is
+  // also contiguous-by-composite. For each group we want the first block's
+  // (start_ts, start_sk) and the last block's (end_ts, end_sk).
+  //
+  // Composite overlap predicate matches nanots_reader::read.
   auto stmt = db.prepare(
     "WITH contiguous_groups AS ( "
     "  SELECT "
     "    sb.segment_id, "
     "    sb.sequence, "
     "    sb.start_timestamp, "
+    "    sb.start_secondary_key, "
     "    sb.end_timestamp, "
+    "    sb.end_secondary_key, "
     "    ROW_NUMBER() OVER (PARTITION BY sb.segment_id ORDER BY sb.sequence) "
     "      - sb.sequence AS group_key "
     "  FROM segment_blocks sb "
     "  JOIN segments s ON sb.segment_id = s.id "
-    "  WHERE sb.start_timestamp <= ? "                    /* bind(1) = window_end    */
-    "    AND (sb.end_timestamp >= ? OR sb.end_timestamp = 0) " /* bind(2) = window_start */
-    "    AND s.stream_tag = ? "                           /* bind(3) = stream_tag    */
+    "  WHERE s.stream_tag = ? "                       /* bind(1) */
+    "    AND (sb.start_timestamp < ? OR "             /* bind(2,3,4) — end composite */
+    "         (sb.start_timestamp = ? AND sb.start_secondary_key <= ?)) "
+    "    AND (sb.end_timestamp = 0 OR sb.end_timestamp > ? OR "  /* bind(5,6,7) — start composite */
+    "         (sb.end_timestamp = ? AND sb.end_secondary_key >= ?)) "
     "), "
     "region_boundaries AS ( "
     "  SELECT "
     "    segment_id, "
     "    group_key, "
-    "    MIN(start_timestamp) AS region_start, "
-    "    CASE "
-    "      WHEN MIN(end_timestamp) = 0 THEN 0 "
-    "      ELSE MAX(end_timestamp) "
-    "    END AS region_end, "
-    "    COUNT(*) AS block_count "
+    "    FIRST_VALUE(start_timestamp) "
+    "      OVER w AS region_start_ts, "
+    "    FIRST_VALUE(start_secondary_key) "
+    "      OVER w AS region_start_sk, "
+    "    LAST_VALUE(end_timestamp) "
+    "      OVER w_full AS region_end_ts, "
+    "    LAST_VALUE(end_secondary_key) "
+    "      OVER w_full AS region_end_sk, "
+    "    COUNT(*) OVER (PARTITION BY segment_id, group_key) AS block_count "
     "  FROM contiguous_groups "
-    "  GROUP BY segment_id, group_key "
+    "  WINDOW "
+    "    w AS (PARTITION BY segment_id, group_key ORDER BY sequence), "
+    "    w_full AS (PARTITION BY segment_id, group_key ORDER BY sequence "
+    "               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) "
     ") "
-    "SELECT "
+    "SELECT DISTINCT "
     "  segment_id, "
-    "  region_start, "
-    "  region_end, "
+    "  region_start_ts, "
+    "  region_start_sk, "
+    "  region_end_ts, "
+    "  region_end_sk, "
     "  block_count "
     "FROM region_boundaries "
-    "ORDER BY segment_id, region_start;"
+    "ORDER BY segment_id, region_start_ts;"
   );
   auto results =
-      stmt.bind(1, end_timestamp).bind(2, start_timestamp).bind(3, stream_tag).exec();
+      stmt.bind(1, stream_tag)
+          .bind(2, end_timestamp).bind(3, end_timestamp).bind(4, end_secondary_key)
+          .bind(5, start_timestamp).bind(6, start_timestamp).bind(7, start_secondary_key)
+          .exec();
 
   std::vector<contiguous_segment> segments;
 
   for (auto& row : results) {
     contiguous_segment segment;
     segment.segment_id = std::stoll(row["segment_id"].value());
-    segment.start_timestamp = std::stoll(row["region_start"].value());
-    segment.end_timestamp = std::stoll(row["region_end"].value());
+    segment.start_timestamp = std::stoll(row["region_start_ts"].value());
+    segment.end_timestamp = std::stoll(row["region_end_ts"].value());
+    auto& s_sk = row["region_start_sk"];
+    auto& e_sk = row["region_end_sk"];
+    segment.start_secondary_key = s_sk.has_value()
+        ? std::stoll(s_sk.value()) : NANOTS_SEC_KEY_UNSET;
+    segment.end_secondary_key = e_sk.has_value()
+        ? std::stoll(e_sk.value()) : NANOTS_SEC_KEY_UNSET;
     segments.push_back(segment);
   }
 
@@ -2917,13 +2982,17 @@ nanots_ec_t nanots_writer_write(nanots_writer_t writer,
 nanots_ec_t nanots_writer_free_blocks(const char* file_name,
                                           const char* stream_tag,
                                           int64_t start_timestamp,
-                                          int64_t end_timestamp) {
+                                          int64_t start_secondary_key,
+                                          int64_t end_timestamp,
+                                          int64_t end_secondary_key) {
   if (!file_name || !stream_tag) {
     return NANOTS_EC_INVALID_ARGUMENT;
   }
 
   try {
-    nanots_writer::free_blocks(std::string(file_name), std::string(stream_tag), start_timestamp, end_timestamp);
+    nanots_writer::free_blocks(std::string(file_name), std::string(stream_tag),
+                               start_timestamp, start_secondary_key,
+                               end_timestamp, end_secondary_key);
     return NANOTS_EC_OK;
   } catch (const nanots_exception& e) {
     return e.get_ec();
@@ -2963,7 +3032,9 @@ struct nanots_callback_context {
 nanots_ec_t nanots_reader_read(nanots_reader_t reader,
                                const char* stream_tag,
                                int64_t start_timestamp,
+                               int64_t start_secondary_key,
                                int64_t end_timestamp,
+                               int64_t end_secondary_key,
                                nanots_read_callback_t callback,
                                void* user_data) {
   if (!reader || !reader->reader) {
@@ -2975,7 +3046,9 @@ nanots_ec_t nanots_reader_read(nanots_reader_t reader,
 
   try {
     nanots_callback_context ctx{callback, user_data};
-    reader->reader->read(std::string(stream_tag), start_timestamp, end_timestamp,
+    reader->reader->read(std::string(stream_tag),
+                         start_timestamp, start_secondary_key,
+                         end_timestamp, end_secondary_key,
                          [&ctx](const uint8_t* data, size_t size, uint32_t flags,
                                 int64_t timestamp, int64_t secondary_key,
                                 int64_t block_sequence, const std::string& metadata) {
@@ -2998,7 +3071,9 @@ nanots_ec_t nanots_reader_query_contiguous_segments(
     nanots_reader_t reader,
     const char* stream_tag,
     int64_t start_timestamp,
+    int64_t start_secondary_key,
     int64_t end_timestamp,
+    int64_t end_secondary_key,
     nanots_contiguous_segment_t** segments,
     size_t* count) {
   if (!reader || !reader->reader) {
@@ -3010,7 +3085,9 @@ nanots_ec_t nanots_reader_query_contiguous_segments(
 
   try {
     auto cpp_segments = reader->reader->query_contiguous_segments(
-        std::string(stream_tag), start_timestamp, end_timestamp);
+        std::string(stream_tag),
+        start_timestamp, start_secondary_key,
+        end_timestamp, end_secondary_key);
 
     *count = cpp_segments.size();
     if (*count == 0) {
@@ -3027,7 +3104,9 @@ nanots_ec_t nanots_reader_query_contiguous_segments(
     for (size_t i = 0; i < *count; i++) {
       (*segments)[i].segment_id = cpp_segments[i].segment_id;
       (*segments)[i].start_timestamp = cpp_segments[i].start_timestamp;
+      (*segments)[i].start_secondary_key = cpp_segments[i].start_secondary_key;
       (*segments)[i].end_timestamp = cpp_segments[i].end_timestamp;
+      (*segments)[i].end_secondary_key = cpp_segments[i].end_secondary_key;
     }
 
     return NANOTS_EC_OK;
@@ -3048,13 +3127,17 @@ void nanots_free_contiguous_segments(nanots_contiguous_segment_t* segments) {
 
 nanots_ec_t nanots_reader_query_stream_tags_start(nanots_reader_t reader,
                                                   int64_t start_timestamp,
-                                                  int64_t end_timestamp) {
+                                                  int64_t start_secondary_key,
+                                                  int64_t end_timestamp,
+                                                  int64_t end_secondary_key) {
   if (!reader || !reader->reader) {
     return NANOTS_EC_INVALID_ARGUMENT;
   }
 
   try {
-    reader->cached_stream_tags = reader->reader->query_stream_tags(start_timestamp, end_timestamp);
+    reader->cached_stream_tags = reader->reader->query_stream_tags(
+        start_timestamp, start_secondary_key,
+        end_timestamp, end_secondary_key);
     reader->stream_tags_iterator = 0;
     return NANOTS_EC_OK;
   } catch (const nanots_exception& e) {

--- a/amalgamated_src/nanots.cpp
+++ b/amalgamated_src/nanots.cpp
@@ -1088,16 +1088,20 @@ static uint32_t _round_to_64k_boundary(uint32_t requested_size) {
 
 static bool _validate_frame_header(const uint8_t* frame_p,
                                    const uint8_t* expected_uuid,
-                                   uint8_t* flags_out,
-                                   uint32_t* size_out) {
+                                   uint32_t* flags_out,
+                                   uint32_t* size_out,
+                                   int64_t* sec_key_out) {
   if (memcmp(frame_p + FRAME_UUID_OFFSET, expected_uuid, 16) != 0)
     return false;
+
+  if (sec_key_out)
+    *sec_key_out = *(int64_t*)(frame_p + FRAME_SECKEY_OFFSET);
 
   if (size_out)
     *size_out = *(uint32_t*)(frame_p + FRAME_SIZE_OFFSET);
 
   if (flags_out)
-    *flags_out = *(frame_p + FRAME_FLAGS_OFFSET);
+    *flags_out = *(uint32_t*)(frame_p + FRAME_FLAGS_OFFSET);
 
   return true;
 }
@@ -1115,35 +1119,35 @@ static void _free_block(nts_sqlite_conn& conn, int sb_id, int block_id) {
   });
 }
 
-static bool _is_valid_frame_at_index(uint8_t* block_p, uint32_t block_size, 
-                                     int index, uint32_t n_valid_indexes, 
+static bool _is_valid_frame_at_index(uint8_t* block_p, uint32_t block_size,
+                                     int index, uint32_t n_valid_indexes,
                                      const uint8_t* uuid) {
   uint8_t* index_p = block_p + BLOCK_HEADER_SIZE + (index * INDEX_ENTRY_SIZE);
-  int64_t timestamp = *(int64_t*)index_p;
-  uint64_t offset = *(uint64_t*)(index_p + 8);
+  int64_t timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+  uint64_t offset = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
   // Skip zeroed entries
   if (timestamp == 0 || offset == 0) {
     return false;
   }
-  
+
   // Check frame offset bounds
   uint32_t index_region_end = BLOCK_HEADER_SIZE + ((n_valid_indexes + 1) * INDEX_ENTRY_SIZE);
   if (offset < index_region_end || offset > block_size - FRAME_HEADER_SIZE) {
     return false;
   }
-  
+
   // Validate frame header
   uint32_t frame_size = 0;
-  if (!_validate_frame_header(block_p + offset, uuid, nullptr, &frame_size)) {
+  if (!_validate_frame_header(block_p + offset, uuid, nullptr, &frame_size, nullptr)) {
     return false;
   }
-  
+
   // Check if frame size fits within block
   if (frame_size > block_size - offset - FRAME_HEADER_SIZE) {
     return false;
   }
-  
+
   return true;
 }
 
@@ -1161,7 +1165,13 @@ static void _validate_blocks(const std::string& file_name) {
         nts_memory_map::NMM_PROT_READ | nts_memory_map::NMM_PROT_WRITE,
         nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED);
 
-    block_size = *(uint32_t*)mm.map();
+    uint8_t* hp = (uint8_t*)mm.map();
+    if (memcmp(hp + FILE_HEADER_MAGIC_OFFSET, NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN) != 0)
+      throw nanots_exception(NANOTS_EC_BAD_MAGIC, "Not a nanots v2 file (bad magic).", __FILE__, __LINE__);
+    uint16_t version = *(uint16_t*)(hp + FILE_HEADER_VERSION_OFFSET);
+    if (version != NANOTS_FORMAT_VERSION)
+      throw nanots_exception(NANOTS_EC_BAD_VERSION, "Unsupported nanots format version.", __FILE__, __LINE__);
+    block_size = *(uint32_t*)(hp + FILE_HEADER_BLOCK_SIZE_OFFSET);
   }
 
   auto db_name = _database_name(file_name);
@@ -1238,13 +1248,15 @@ static void _validate_blocks(const std::string& file_name) {
         nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
           uint8_t* last_index_p =
               block_p + BLOCK_HEADER_SIZE + (last_valid * INDEX_ENTRY_SIZE);
-          int64_t actual_last_timestamp = *(int64_t*)last_index_p;
+          int64_t actual_last_timestamp = *(int64_t*)(last_index_p + INDEX_ENTRY_TS_OFFSET);
+          int64_t actual_last_sk = *(int64_t*)(last_index_p + INDEX_ENTRY_SECKEY_OFFSET);
           auto stmt = conn.prepare(
-              "UPDATE segment_blocks SET end_timestamp = ? WHERE block_idx = ? AND uuid "
-              "= ?");
+              "UPDATE segment_blocks SET end_timestamp = ?, end_secondary_key = ? "
+              "WHERE block_idx = ? AND uuid = ?");
           stmt.bind(1, actual_last_timestamp)
-              .bind(2, block_idx)
-              .bind(3, uuid_hex)
+              .bind(2, actual_last_sk)
+              .bind(3, block_idx)
+              .bind(4, uuid_hex)
               .exec_no_result();
         });
       }
@@ -1269,10 +1281,18 @@ static void _set_db_version(const nts_sqlite_conn& conn, int version) {
 static void _upgrade_db(const nts_sqlite_conn& conn) {
   auto current_version = _get_db_version(conn);
 
+  // v2-only build: any pre-v2 database is rejected. (Fresh DBs created by
+  // allocate() are stamped to version 2 below.)
+  if (current_version != 0 && current_version < 2) {
+    throw nanots_exception(NANOTS_EC_BAD_VERSION,
+                           "Legacy nanots catalog (pre-v2) is not supported.",
+                           __FILE__, __LINE__);
+  }
+
   switch (current_version) {
     case 0: {
       nts_sqlite_transaction(
-          conn, true, [&](const nts_sqlite_conn& conn) { _set_db_version(conn, 1); });
+          conn, true, [&](const nts_sqlite_conn& conn) { _set_db_version(conn, 2); });
     }
       [[fallthrough]];
     default:
@@ -1332,14 +1352,36 @@ static std::optional<block> _db_get_free_block(const nts_sqlite_conn& conn) {
 //  which composes _db_get_free_block / _grow_blocks / _db_reclaim_oldest_used_block
 //  with the EBR limbo/ready machinery.)
 
+// Look up whether any existing segment for this stream tag uses the secondary
+// key. Returns nullopt if no segment exists yet for this stream (caller's
+// choice will become the canonical one), or the 0/1 value otherwise.
+static std::optional<int> _db_lookup_stream_has_secondary_key(
+    const nts_sqlite_conn& conn, const std::string& stream_tag) {
+  auto stmt = conn.prepare(
+      "SELECT has_secondary_key FROM segments WHERE stream_tag = ? LIMIT 1");
+  auto rows = stmt.bind(1, stream_tag).exec();
+  if (rows.empty()) return std::nullopt;
+  return std::stoi(rows.front()["has_secondary_key"].value());
+}
+
 static std::optional<segment> _db_create_segment(const nts_sqlite_conn& conn,
                                                  const std::string& stream_tag,
-                                                 const std::string& metadata) {
-  auto stmt =
-      conn.prepare("INSERT INTO segments (stream_tag, metadata) VALUES (?, ?)");
-  stmt.bind(1, stream_tag).bind(2, metadata).exec_no_result();
+                                                 const std::string& metadata,
+                                                 bool has_secondary_key) {
+  auto stmt = conn.prepare(
+      "INSERT INTO segments (stream_tag, metadata, has_secondary_key) VALUES (?, ?, ?)");
+  stmt.bind(1, stream_tag)
+      .bind(2, metadata)
+      .bind(3, has_secondary_key ? 1 : 0)
+      .exec_no_result();
 
-  return segment{std::stoll(conn.last_insert_id()), stream_tag, metadata, 0};
+  segment s;
+  s.id = std::stoll(conn.last_insert_id());
+  s.stream_tag = stream_tag;
+  s.metadata = metadata;
+  s.sequence = 0;
+  s.has_secondary_key = has_secondary_key;
+  return s;
 }
 
 static std::optional<segment_block> _db_create_segment_block(
@@ -1350,6 +1392,8 @@ static std::optional<segment_block> _db_create_segment_block(
     int64_t block_idx,
     int64_t start_timestamp,
     int64_t end_timestamp,
+    int64_t start_secondary_key,
+    int64_t end_secondary_key,
     const uint8_t* uuid) {
   auto stmt = conn.prepare(
       "INSERT INTO segment_blocks ("
@@ -1359,8 +1403,10 @@ static std::optional<segment_block> _db_create_segment_block(
       "block_idx, "
       "start_timestamp, "
       "end_timestamp, "
+      "start_secondary_key, "
+      "end_secondary_key, "
       "uuid"
-      ") VALUES (?, ?, ?, ?, ?, ?, ?)");
+      ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
   auto hex_uuid = entropy_id_to_s(uuid);
 
@@ -1370,7 +1416,9 @@ static std::optional<segment_block> _db_create_segment_block(
       .bind(4, block_idx)
       .bind(5, start_timestamp)
       .bind(6, end_timestamp)
-      .bind(7, hex_uuid)
+      .bind(7, start_secondary_key)
+      .bind(8, end_secondary_key)
+      .bind(9, hex_uuid)
       .exec_no_result();
 
   struct segment_block sb;
@@ -1381,6 +1429,8 @@ static std::optional<segment_block> _db_create_segment_block(
   sb.block_idx = block_idx;
   sb.start_timestamp = start_timestamp;
   sb.end_timestamp = end_timestamp;
+  sb.start_secondary_key = start_secondary_key;
+  sb.end_secondary_key = end_secondary_key;
   memcpy(sb.uuid, uuid, 16);
 
   return sb;
@@ -1388,9 +1438,15 @@ static std::optional<segment_block> _db_create_segment_block(
 
 static void _db_finalize_block(const nts_sqlite_conn& conn,
                                int64_t segment_block_id,
-                               int64_t timestamp) {
-  auto stmt = conn.prepare("UPDATE segment_blocks SET end_timestamp = ? WHERE id = ?");
-  stmt.bind(1, timestamp).bind(2, segment_block_id).exec_no_result();
+                               int64_t timestamp,
+                               int64_t secondary_key) {
+  auto stmt = conn.prepare(
+      "UPDATE segment_blocks SET end_timestamp = ?, end_secondary_key = ? "
+      "WHERE id = ?");
+  stmt.bind(1, timestamp)
+      .bind(2, secondary_key)
+      .bind(3, segment_block_id)
+      .exec_no_result();
 }
 
 static void _db_trans_finalize_reserved_blocks(const nts_sqlite_conn& conn) {
@@ -1447,8 +1503,10 @@ write_context::~write_context() {
     auto db_name = _database_name(file_name);
     nts_sqlite_conn conn(db_name, true, true);
 
+    int64_t end_sk = last_secondary_key.value_or(NANOTS_SEC_KEY_UNSET);
+
     nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-      _db_finalize_block(conn, current_block->id, last_timestamp.value());
+      _db_finalize_block(conn, current_block->id, last_timestamp.value(), end_sk);
       // This is a maintenance task that needs to be done periodically.
       _db_trans_finalize_reserved_blocks(conn);
     });
@@ -1466,16 +1524,24 @@ nanots_writer::nanots_writer(const std::string& file_name, bool auto_reclaim)
           nts_memory_map::NMM_PROT_READ | nts_memory_map::NMM_PROT_WRITE,
           nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED),
       _file_header_p((uint8_t*)_file_header_mm.map()),
-      _block_size(*(uint32_t*)_file_header_p),
-      _n_blocks(*(uint32_t*)(_file_header_p + sizeof(uint32_t))),
-      // max_blocks lives at offset 8. For legacy preallocated files this byte
-      // range was zeroed by fallocate (Linux/macOS) or left at whatever
-      // SetEndOfFile produced (Windows). Only consulted in growable mode, and
-      // new allocate() always writes 0 here, so legacy preallocated files are
-      // unaffected.
-      _max_blocks(*(uint32_t*)(_file_header_p + 8)),
+      _block_size(*(uint32_t*)(_file_header_p + FILE_HEADER_BLOCK_SIZE_OFFSET)),
+      _n_blocks(*(uint32_t*)(_file_header_p + FILE_HEADER_N_BLOCKS_OFFSET)),
+      _max_blocks(*(uint32_t*)(_file_header_p + FILE_HEADER_MAX_BLOCKS_OFFSET)),
       _auto_reclaim(auto_reclaim),
       _epoch(nanots_epoch_registry::get_or_create(file_name)) {
+  // Validate v2 magic + version up front. Legacy v1 files (which had
+  // block_size at offset 0) are rejected by design.
+  if (memcmp(_file_header_p + FILE_HEADER_MAGIC_OFFSET,
+             NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN) != 0)
+    throw nanots_exception(NANOTS_EC_BAD_MAGIC,
+                           "Not a nanots v2 file (bad magic). Legacy v1 files are not supported.",
+                           __FILE__, __LINE__);
+  uint16_t version = *(uint16_t*)(_file_header_p + FILE_HEADER_VERSION_OFFSET);
+  if (version != NANOTS_FORMAT_VERSION)
+    throw nanots_exception(NANOTS_EC_BAD_VERSION,
+                           "Unsupported nanots format version.",
+                           __FILE__, __LINE__);
+
   if (_block_size < 4096 || _block_size > 1024 * 1024 * 1024)
     throw nanots_exception(NANOTS_EC_INVALID_BLOCK_SIZE, "Invalid block size in file header.", __FILE__, __LINE__);
 
@@ -1540,7 +1606,7 @@ write_context nanots_writer::create_write_context(const std::string& stream_tag,
                                                   const std::string& metadata) {
 
   std::string key = _file_name + ":" + stream_tag;
-  
+
   std::lock_guard<std::mutex> g(current_stream_tags_lok);
   if(current_stream_tags.find(key) != current_stream_tags.end())
     throw nanots_exception(NANOTS_EC_DUPLICATE_STREAM_TAG, "Only one current writer per active stream tag.", __FILE__, __LINE__);
@@ -1551,15 +1617,9 @@ write_context nanots_writer::create_write_context(const std::string& stream_tag,
   wctx.file_name = _file_name;
   wctx._block_size = _block_size;
 
-  auto db_name = _database_name(_file_name);
-
-  nts_sqlite_conn conn(db_name.c_str(), true, true);
-
-  nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-    wctx.current_segment = _db_create_segment(conn, stream_tag, metadata);
-    if (!wctx.current_segment)
-      throw nanots_exception(NANOTS_EC_UNABLE_TO_CREATE_SEGMENT, "Unable to create segment.", __FILE__, __LINE__);
-  });
+  // Segment creation is deferred to the first write(): only then do we know
+  // whether the caller intends this stream to carry a secondary key, which
+  // is recorded permanently on the segments row.
 
   current_stream_tags.insert(key);
 
@@ -1657,14 +1717,59 @@ block nanots_writer::_acquire_writable_block(const nts_sqlite_conn& conn) {
 void nanots_writer::write(write_context& wctx,
                           const uint8_t* data,
                           size_t size,
+                          uint32_t flags,
                           int64_t timestamp,
-                          uint8_t flags) {
+                          int64_t secondary_key) {
   if (wctx.last_timestamp && timestamp <= wctx.last_timestamp.value())
     throw nanots_exception(NANOTS_EC_NON_MONOTONIC_TIMESTAMP, "Timestamp is not monotonic.", __FILE__, __LINE__);
 
   if (size >
       _block_size - (FRAME_HEADER_SIZE + INDEX_ENTRY_SIZE + BLOCK_HEADER_SIZE))
     throw nanots_exception(NANOTS_EC_ROW_SIZE_TOO_BIG, "Frame size is too large. Use a much larger block size.", __FILE__, __LINE__);
+
+  // First write to this context: lazily create (or attach to) the segment
+  // row. The very first write to a brand-new stream tag fixes the choice of
+  // whether the stream stores a secondary key on every frame.
+  if (!wctx.current_segment) {
+    bool wants_sec_key = (secondary_key != NANOTS_SEC_KEY_UNSET);
+
+    nts_sqlite_conn conn(_database_name(_file_name), true, true);
+    nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
+      auto existing = _db_lookup_stream_has_secondary_key(conn, wctx.stream_tag);
+      if (existing.has_value()) {
+        bool existing_yes = (*existing != 0);
+        if (existing_yes != wants_sec_key) {
+          throw nanots_exception(
+              NANOTS_EC_SECONDARY_KEY_MISMATCH,
+              "Stream's secondary-key mode is fixed by its first write and "
+              "this write does not match.", __FILE__, __LINE__);
+        }
+      }
+      wctx.current_segment = _db_create_segment(
+          conn, wctx.stream_tag, wctx.metadata, wants_sec_key);
+      if (!wctx.current_segment)
+        throw nanots_exception(NANOTS_EC_UNABLE_TO_CREATE_SEGMENT, "Unable to create segment.", __FILE__, __LINE__);
+    });
+  } else {
+    // Subsequent writes: enforce the per-stream choice that was locked in
+    // on the first write.
+    bool stream_wants = wctx.current_segment->has_secondary_key;
+    bool this_write_provides = (secondary_key != NANOTS_SEC_KEY_UNSET);
+    if (stream_wants != this_write_provides) {
+      throw nanots_exception(
+          NANOTS_EC_SECONDARY_KEY_MISMATCH,
+          "Stream's secondary-key mode is fixed and this write does not match.",
+          __FILE__, __LINE__);
+    }
+  }
+
+  if (secondary_key != NANOTS_SEC_KEY_UNSET &&
+      wctx.last_secondary_key.has_value() &&
+      secondary_key <= wctx.last_secondary_key.value()) {
+    throw nanots_exception(NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY,
+                           "Secondary key is not monotonic.",
+                           __FILE__, __LINE__);
+  }
 
   if (!wctx.current_block) {
     nts_sqlite_conn conn(_database_name(_file_name), true, true);
@@ -1682,7 +1787,7 @@ void nanots_writer::write(write_context& wctx,
 
       wctx.current_block = _db_create_segment_block(
           conn, wctx.current_segment->id, wctx.current_segment->sequence,
-          phys.id, phys.idx, timestamp, 0, uuid);
+          phys.id, phys.idx, timestamp, 0, secondary_key, 0, uuid);
 
       if (!wctx.current_block)
         throw nanots_exception(NANOTS_EC_UNABLE_TO_CREATE_SEGMENT_BLOCK, "Unable to create segment block.", __FILE__, __LINE__);
@@ -1718,7 +1823,7 @@ void nanots_writer::write(write_context& wctx,
   if (n_valid_indexes > 0) {
     uint8_t* last_index_p = block_p + BLOCK_HEADER_SIZE +
                             ((n_valid_indexes - 1) * INDEX_ENTRY_SIZE);
-    uint64_t last_frame_offset = *(uint64_t*)(last_index_p + 8);
+    uint64_t last_frame_offset = *(uint64_t*)(last_index_p + INDEX_ENTRY_OFFSET_OFFSET);
     if (last_frame_offset >= padded_frame_size) {
       uint64_t candidate_ofs = last_frame_offset - padded_frame_size;
       new_block_ofs = (candidate_ofs >= index_end) ? candidate_ofs : index_end;
@@ -1732,26 +1837,31 @@ void nanots_writer::write(write_context& wctx,
 
     wctx.mm.flush(wctx.mm.map(), _block_size, true);
 
+    int64_t end_sk = wctx.last_secondary_key.value_or(NANOTS_SEC_KEY_UNSET);
     nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-      _db_finalize_block(conn, wctx.current_block->id, wctx.last_timestamp.value());
+      _db_finalize_block(conn, wctx.current_block->id,
+                         wctx.last_timestamp.value(), end_sk);
     });
 
     wctx.current_block = std::nullopt;
     wctx.mm = nts_memory_map();
 
-    return write(wctx, data, size, timestamp, flags);
+    return write(wctx, data, size, flags, timestamp, secondary_key);
   }
 
   uint8_t* frame_p = block_p + new_block_ofs;
-  memcpy(frame_p, wctx.current_block->uuid, 16);
-  *(uint32_t*)(frame_p + 16) = (uint32_t)size;
-  *(frame_p + 20) = flags;
+  memcpy(frame_p + FRAME_UUID_OFFSET, wctx.current_block->uuid, 16);
+  *(int64_t*)(frame_p + FRAME_SECKEY_OFFSET) = secondary_key;
+  *(uint32_t*)(frame_p + FRAME_SIZE_OFFSET) = (uint32_t)size;
+  *(uint32_t*)(frame_p + FRAME_FLAGS_OFFSET) = flags;
   memcpy(frame_p + FRAME_HEADER_SIZE, data, size);
 
   uint8_t* index_p =
       block_p + BLOCK_HEADER_SIZE + (n_valid_indexes * INDEX_ENTRY_SIZE);
-  *(int64_t*)index_p = timestamp;
-  *(uint64_t*)(index_p + 8) = new_block_ofs;
+  *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET) = timestamp;
+  *(int64_t*)(index_p + INDEX_ENTRY_SECKEY_OFFSET) = secondary_key;
+  *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET) = new_block_ofs;
+  *(uint64_t*)(index_p + INDEX_ENTRY_RESERVED_OFFSET) = 0;
 
   auto valid_counter = (uint32_t*)(block_p + 8);
 
@@ -1762,6 +1872,8 @@ void nanots_writer::write(write_context& wctx,
 #endif
 
   wctx.last_timestamp = timestamp;
+  if (secondary_key != NANOTS_SEC_KEY_UNSET)
+    wctx.last_secondary_key = secondary_key;
 }
 
 void nanots_writer::free_blocks(const std::string& file_name,
@@ -1803,7 +1915,6 @@ void nanots_writer::allocate_growable(const std::string& file_name,
                                       uint32_t block_size,
                                       uint32_t max_blocks) {
   // Growable mode is signalled by n_blocks == 0 in the file header.
-  // The optional max_blocks cap is stored at offset 8.
   allocate(file_name, block_size, 0);
 
   if (max_blocks > 0) {
@@ -1813,8 +1924,8 @@ void nanots_writer::allocate_growable(const std::string& file_name,
         nts_memory_map::NMM_PROT_READ | nts_memory_map::NMM_PROT_WRITE,
         nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED);
     uint8_t* p = (uint8_t*)mm.map();
-    *(uint32_t*)(p + 8) = max_blocks;
-    mm.flush(mm.map(), 12);
+    *(uint32_t*)(p + FILE_HEADER_MAX_BLOCKS_OFFSET) = max_blocks;
+    mm.flush(mm.map(), FILE_HEADER_USED_BYTES);
   }
 }
 
@@ -1847,16 +1958,19 @@ void nanots_writer::allocate(const std::string& file_name,
 
     uint8_t* p = (uint8_t*)mm.map();
 
-    // write a file header
-    *(uint32_t*)p = block_size;
-    p += sizeof(uint32_t);
-    *(uint32_t*)p = n_blocks;
-    p += sizeof(uint32_t);
-    // offset 8: max_blocks cap for growable mode (0 = unbounded). Always
-    // zero here; allocate_growable() overwrites it if a cap was requested.
-    *(uint32_t*)p = 0;
+    // Write the v2 file header. Zero the first 64 bytes first so we have a
+    // clean slate (fallocate / SetEndOfFile leave indeterminate bytes here).
+    memset(p, 0, 64);
+    memcpy(p + FILE_HEADER_MAGIC_OFFSET, NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN);
+    *(uint16_t*)(p + FILE_HEADER_VERSION_OFFSET) = (uint16_t)NANOTS_FORMAT_VERSION;
+    *(uint16_t*)(p + FILE_HEADER_HSIZE_OFFSET)   = (uint16_t)FILE_HEADER_USED_BYTES;
+    *(uint32_t*)(p + FILE_HEADER_BLOCK_SIZE_OFFSET) = block_size;
+    *(uint32_t*)(p + FILE_HEADER_N_BLOCKS_OFFSET)   = n_blocks;
+    *(uint32_t*)(p + FILE_HEADER_MAX_BLOCKS_OFFSET) = 0;
+    *(uint32_t*)(p + FILE_HEADER_FLAGS_OFFSET)      = 0;
+    *(uint64_t*)(p + FILE_HEADER_FEATURES_OFFSET)   = 0;
 
-    mm.flush(mm.map(), 12);
+    mm.flush(mm.map(), 64);
   }
 
   auto db_name = _database_name(file_name);
@@ -1879,7 +1993,8 @@ void nanots_writer::allocate(const std::string& file_name,
       "CREATE TABLE segments ("
       "id INTEGER PRIMARY KEY AUTOINCREMENT, "
       "stream_tag STRING, "
-      "metadata STRING "
+      "metadata STRING, "
+      "has_secondary_key INTEGER NOT NULL DEFAULT 0"
       ");";
   db.exec(query);
 
@@ -1892,6 +2007,8 @@ void nanots_writer::allocate(const std::string& file_name,
       "block_idx INTEGER, "
       "start_timestamp INTEGER, "
       "end_timestamp INTEGER, "
+      "start_secondary_key INTEGER, "
+      "end_secondary_key INTEGER, "
       "uuid STRING, "
       "FOREIGN KEY (segment_id) REFERENCES segments(id)"
       ");";
@@ -1917,6 +2034,11 @@ void nanots_writer::allocate(const std::string& file_name,
 
   query =
       "CREATE INDEX idx_segment_blocks_time_range ON segment_blocks(start_timestamp);";
+  db.exec(query);
+
+  query =
+      "CREATE INDEX idx_segment_blocks_sec_key ON "
+      "segment_blocks(segment_id, start_secondary_key);";
   db.exec(query);
 
   query = "CREATE INDEX idx_segments_stream_tag ON segments(stream_tag);";
@@ -1949,14 +2071,24 @@ nanots_reader::nanots_reader(const std::string& file_name)
 
   auto header_p = (uint8_t*)mm.map();
 
-  _block_size = *(uint32_t*)header_p;
+  if (memcmp(header_p + FILE_HEADER_MAGIC_OFFSET,
+             NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN) != 0)
+    throw nanots_exception(NANOTS_EC_BAD_MAGIC,
+                           "Not a nanots v2 file (bad magic).",
+                           __FILE__, __LINE__);
+  uint16_t version = *(uint16_t*)(header_p + FILE_HEADER_VERSION_OFFSET);
+  if (version != NANOTS_FORMAT_VERSION)
+    throw nanots_exception(NANOTS_EC_BAD_VERSION,
+                           "Unsupported nanots format version.",
+                           __FILE__, __LINE__);
 
-  _n_blocks = (*(uint32_t*)(header_p + sizeof(uint32_t)));
+  _block_size = *(uint32_t*)(header_p + FILE_HEADER_BLOCK_SIZE_OFFSET);
+  _n_blocks   = *(uint32_t*)(header_p + FILE_HEADER_N_BLOCKS_OFFSET);
 }
 
 static int _compare_index_entry_timestamp(uint8_t* index_entry_p,
                                           uint8_t* target_timestamp_p) {
-  int64_t entry_timestamp = *(int64_t*)index_entry_p;
+  int64_t entry_timestamp = *(int64_t*)(index_entry_p + INDEX_ENTRY_TS_OFFSET);
   int64_t target_timestamp = *(int64_t*)target_timestamp_p;
 
   if (entry_timestamp < target_timestamp)
@@ -1966,12 +2098,24 @@ static int _compare_index_entry_timestamp(uint8_t* index_entry_p,
   return 0;
 }
 
+static int _compare_index_entry_secondary_key(uint8_t* index_entry_p,
+                                              uint8_t* target_sk_p) {
+  int64_t entry_sk = *(int64_t*)(index_entry_p + INDEX_ENTRY_SECKEY_OFFSET);
+  int64_t target_sk = *(int64_t*)target_sk_p;
+
+  if (entry_sk < target_sk)
+    return -1;
+  if (entry_sk > target_sk)
+    return 1;
+  return 0;
+}
+
 void nanots_reader::read(
     const std::string& stream_tag,
     int64_t start_timestamp,
     int64_t end_timestamp,
     const std::function<
-        void(const uint8_t*, size_t, uint8_t, int64_t, int64_t, const std::string&)>& callback) {
+        void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback) {
   // EBR critical section spans the entire read(): the writer must not
   // overwrite any block whose bytes the callback might dereference.
   nanots_op_scope _op(_slot_guard);
@@ -2039,25 +2183,26 @@ void nanots_reader::read(
     // Iterate through frames in this block
     for (size_t i = start_index; i < n_valid_indexes; i++) {
       uint8_t* index_p = block_p + BLOCK_HEADER_SIZE + (i * INDEX_ENTRY_SIZE);
-      int64_t timestamp = *(int64_t*)index_p;
-      uint64_t offset = *(uint64_t*)(index_p + 8);
+      int64_t timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+      uint64_t offset   = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
       // Check if we've passed the end time
       if (timestamp > end_timestamp)
         return;  // All done!
 
       // Validate frame header
-      uint8_t flags;
+      uint32_t flags;
       uint32_t frame_size;
+      int64_t sec_key;
       if (!_validate_frame_header(block_p + offset, uuid, &flags,
-                                  &frame_size)) {
+                                  &frame_size, &sec_key)) {
         // Log warning? Skip corrupted frame
         continue;
       }
 
       // Callback with frame data
       callback(block_p + offset + FRAME_HEADER_SIZE, (size_t)frame_size, flags,
-               timestamp, block_sequence, metadata);
+               timestamp, sec_key, block_sequence, metadata);
     }
   }
 }
@@ -2156,16 +2301,43 @@ nanots_iterator::nanots_iterator(const std::string& file_name,
       _valid(false),
       _initialized(false),
       _slot_guard(nanots_epoch_registry::get_or_create(file_name)) {
-  // Read block size from file header
+  // Read block size + validate magic/version from file header.
   auto header_mm = nts_memory_map(
       filenum(_file), 0, FILE_HEADER_BLOCK_SIZE, nts_memory_map::NMM_PROT_READ,
       nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED);
 
   auto header_p = (uint8_t*)header_mm.map();
-  _block_size = *(uint32_t*)header_p;
+
+  if (memcmp(header_p + FILE_HEADER_MAGIC_OFFSET,
+             NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN) != 0)
+    throw nanots_exception(NANOTS_EC_BAD_MAGIC,
+                           "Not a nanots v2 file (bad magic).",
+                           __FILE__, __LINE__);
+  uint16_t version = *(uint16_t*)(header_p + FILE_HEADER_VERSION_OFFSET);
+  if (version != NANOTS_FORMAT_VERSION)
+    throw nanots_exception(NANOTS_EC_BAD_VERSION,
+                           "Unsupported nanots format version.",
+                           __FILE__, __LINE__);
+
+  _block_size = *(uint32_t*)(header_p + FILE_HEADER_BLOCK_SIZE_OFFSET);
 
   // Initialize to first frame if stream exists
   reset();
+}
+
+bool nanots_iterator::has_secondary_key() {
+  if (_has_secondary_key_cache >= 0) return _has_secondary_key_cache != 0;
+  auto& db = _ensure_db_connection();
+  auto stmt = db.prepare(
+      "SELECT has_secondary_key FROM segments WHERE stream_tag = ? LIMIT 1");
+  auto rows = stmt.bind(1, _stream_tag).exec();
+  int v = 0;
+  if (!rows.empty()) {
+    auto& cell = rows.front()["has_secondary_key"];
+    if (cell.has_value()) v = std::stoi(cell.value());
+  }
+  _has_secondary_key_cache = v;
+  return v != 0;
 }
 
 nts_sqlite_conn& nanots_iterator::_ensure_db_connection() {
@@ -2188,11 +2360,14 @@ block_info* nanots_iterator::_get_block_by_segment_and_sequence(int64_t segment_
     _stmt_get_block_by_id.emplace(_ensure_db_connection().prepare(
         "SELECT "
         "s.metadata as metadata, "
+        "s.has_secondary_key as has_secondary_key, "
         "sb.segment_id as segment_id, "
         "sb.sequence as block_sequence, "
         "sb.block_idx as block_idx, "
         "sb.start_timestamp as start_timestamp, "
         "sb.end_timestamp as end_timestamp, "
+        "sb.start_secondary_key as start_secondary_key, "
+        "sb.end_secondary_key as end_secondary_key, "
         "sb.uuid as uuid "
         "FROM segments s "
         "JOIN segment_blocks sb ON sb.segment_id = s.id "
@@ -2211,11 +2386,21 @@ block_info* nanots_iterator::_get_block_by_segment_and_sequence(int64_t segment_
   block.block_idx = std::stoll(row["block_idx"].value());
   block.block_sequence = std::stoll(row["block_sequence"].value());
   block.segment_id = std::stoll(row["segment_id"].value());
-  block.metadata = row["metadata"].value();
+  // Metadata may legitimately be the empty string, which the sqlite wrapper
+  // reports as a missing optional.
+  block.metadata = row["metadata"].has_value() ? row["metadata"].value() : std::string();
   block.uuid_hex = row["uuid"].value();
   block.start_timestamp = std::stoll(row["start_timestamp"].value());
   block.end_timestamp = std::stoll(row["end_timestamp"].value());
-  
+  auto& hsk = row["has_secondary_key"];
+  block.has_secondary_key = hsk.has_value() && std::stoi(hsk.value()) != 0;
+  auto& sk_start = row["start_secondary_key"];
+  block.start_secondary_key = sk_start.has_value()
+      ? std::stoll(sk_start.value()) : NANOTS_SEC_KEY_UNSET;
+  auto& sk_end = row["end_secondary_key"];
+  block.end_secondary_key = sk_end.has_value()
+      ? std::stoll(sk_end.value()) : NANOTS_SEC_KEY_UNSET;
+
   auto result = _block_cache.emplace(cache_key, std::move(block));
   return &result.first->second;
 }
@@ -2236,7 +2421,8 @@ void nanots_iterator::_refresh_ts_index() {
   // already in start_ts order — no sort needed.
   auto stmt = db.prepare(
       "SELECT sb.segment_id, sb.sequence, "
-      "       sb.start_timestamp, sb.end_timestamp "
+      "       sb.start_timestamp, sb.end_timestamp, "
+      "       sb.start_secondary_key, sb.end_secondary_key "
       "FROM segments s "
       "JOIN segment_blocks sb ON sb.segment_id = s.id "
       "WHERE s.stream_tag = ? "
@@ -2251,9 +2437,32 @@ void nanots_iterator::_refresh_ts_index() {
     br.sequence   = std::stoll(row["sequence"].value());
     br.start_ts   = std::stoll(row["start_timestamp"].value());
     br.end_ts     = std::stoll(row["end_timestamp"].value());
+    auto& s_sk = row["start_secondary_key"];
+    auto& e_sk = row["end_secondary_key"];
+    br.start_sk = s_sk.has_value() ? std::stoll(s_sk.value())
+                                   : NANOTS_SEC_KEY_UNSET;
+    br.end_sk   = e_sk.has_value() ? std::stoll(e_sk.value())
+                                   : NANOTS_SEC_KEY_UNSET;
     _ts_index.push_back(br);
   }
   _ts_index_filled = true;
+}
+
+size_t nanots_iterator::_ts_index_find_by_sk(int64_t sk) const {
+  // Prefer a block that covers sk.
+  auto it = std::upper_bound(_ts_index.begin(), _ts_index.end(), sk,
+      [](int64_t k, const BlockRange& br) { return k < br.start_sk; });
+  if (it != _ts_index.begin()) {
+    auto prev = std::prev(it);
+    if (sk >= prev->start_sk &&
+        (prev->end_sk == 0 || sk <= prev->end_sk)) {
+      return static_cast<size_t>(std::distance(_ts_index.begin(), prev));
+    }
+  }
+  if (it != _ts_index.end()) {
+    return static_cast<size_t>(std::distance(_ts_index.begin(), it));
+  }
+  return _ts_index.size();
 }
 
 size_t nanots_iterator::_ts_index_find(int64_t ts) const {
@@ -2391,6 +2600,73 @@ block_info* nanots_iterator::_find_block_for_timestamp(int64_t timestamp) {
   return try_at(pos);
 }
 
+block_info* nanots_iterator::_find_block_for_secondary_key(int64_t sec_key) {
+  _ensure_ts_index();
+
+  auto try_at = [&](size_t pos) -> block_info* {
+    if (pos >= _ts_index.size()) return nullptr;
+    const auto& br = _ts_index[pos];
+    auto* b = _get_block_by_segment_and_sequence(br.segment_id, br.sequence);
+    if (b) _ts_index_pos = pos;
+    return b;
+  };
+
+  size_t pos = _ts_index_find_by_sk(sec_key);
+  if (auto* b = try_at(pos)) return b;
+
+  _refresh_ts_index();
+  pos = _ts_index_find_by_sk(sec_key);
+  return try_at(pos);
+}
+
+bool nanots_iterator::find_by_secondary_key(int64_t sec_key) {
+  nanots_op_scope _op(_slot_guard);
+
+  if (!has_secondary_key()) {
+    _valid = false;
+    return false;
+  }
+
+  block_info* block = _find_block_for_secondary_key(sec_key);
+  if (!block) {
+    _valid = false;
+    return false;
+  }
+
+  if (!_load_block_data(*block)) {
+    _valid = false;
+    return false;
+  }
+
+  _current_block_start_ts = block->start_timestamp;
+  _current_block_end_ts   = block->end_timestamp;
+  _current_segment_id     = block->segment_id;
+  _current_block_sequence = block->block_sequence;
+
+  uint8_t* index_start = block->block_p + BLOCK_HEADER_SIZE;
+  uint8_t* index_end   = index_start + (block->n_valid_indexes * INDEX_ENTRY_SIZE);
+
+  uint8_t* found_entry =
+      lower_bound_bytes(index_start, index_end, (uint8_t*)&sec_key,
+                        INDEX_ENTRY_SIZE,
+                        _compare_index_entry_secondary_key);
+
+  _current_frame_idx = (found_entry - index_start) / INDEX_ENTRY_SIZE;
+
+  if (_current_frame_idx >= block->n_valid_indexes) {
+    auto* next_block = _get_next_block();
+    if (!next_block) {
+      _valid = false;
+      return false;
+    }
+    _current_segment_id = next_block->segment_id;
+    _current_block_sequence = next_block->block_sequence;
+    _current_frame_idx = 0;
+  }
+
+  return _load_current_frame();
+}
+
 bool nanots_iterator::_load_block_data(block_info& block) {
   if (block.is_loaded)
     return true;
@@ -2439,14 +2715,15 @@ bool nanots_iterator::_load_current_frame() {
   // Get frame info from index
   uint8_t* index_p = block->block_p + BLOCK_HEADER_SIZE +
                      (_current_frame_idx * INDEX_ENTRY_SIZE);
-  int64_t timestamp = *(int64_t*)index_p;
-  uint64_t offset = *(uint64_t*)(index_p + 8);
+  int64_t timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+  uint64_t offset   = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
   // Validate frame header
-  uint8_t flags;
+  uint32_t flags;
   uint32_t frame_size;
+  int64_t sec_key;
   if (!_validate_frame_header(block->block_p + offset, block->uuid, &flags,
-                              &frame_size)) {
+                              &frame_size, &sec_key)) {
     _valid = false;
     return false;
   }
@@ -2456,6 +2733,7 @@ bool nanots_iterator::_load_current_frame() {
   _current_frame.size = frame_size;
   _current_frame.flags = flags;
   _current_frame.timestamp = timestamp;
+  _current_frame.secondary_key = sec_key;
   _current_frame.block_sequence = block->block_sequence;
 
   _valid = true;
@@ -2578,14 +2856,15 @@ bool nanots_iterator::find(int64_t timestamp) {
   // Get frame info from index
   uint8_t* index_p = block->block_p + BLOCK_HEADER_SIZE +
                      (_current_frame_idx * INDEX_ENTRY_SIZE);
-  int64_t found_timestamp = *(int64_t*)index_p;
-  uint64_t offset = *(uint64_t*)(index_p + 8);
+  int64_t found_timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+  uint64_t offset = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
   // Validate frame header
-  uint8_t flags;
+  uint32_t flags;
   uint32_t frame_size;
+  int64_t sec_key;
   if (!_validate_frame_header(block->block_p + offset, block->uuid, &flags,
-                              &frame_size)) {
+                              &frame_size, &sec_key)) {
     _valid = false;
     return false;
   }
@@ -2595,6 +2874,7 @@ bool nanots_iterator::find(int64_t timestamp) {
   _current_frame.size = frame_size;
   _current_frame.flags = flags;
   _current_frame.timestamp = found_timestamp;
+  _current_frame.secondary_key = sec_key;
   _current_frame.block_sequence = block->block_sequence;
 
   _valid = true;
@@ -2754,8 +3034,9 @@ nanots_ec_t nanots_writer_write(nanots_writer_t writer,
                                 nanots_write_context_t context,
                                 const uint8_t* data,
                                 size_t size,
+                                uint32_t flags,
                                 int64_t timestamp,
-                                uint8_t flags) {
+                                int64_t secondary_key) {
   if (!writer || !writer->writer) {
     return NANOTS_EC_INVALID_ARGUMENT;
   }
@@ -2764,7 +3045,8 @@ nanots_ec_t nanots_writer_write(nanots_writer_t writer,
   }
 
   try {
-    writer->writer->write(context->context, data, size, timestamp, flags);
+    writer->writer->write(context->context, data, size,
+                          flags, timestamp, secondary_key);
     return NANOTS_EC_OK;
   } catch (const nanots_exception& e) {
     return e.get_ec();
@@ -2839,9 +3121,10 @@ nanots_ec_t nanots_reader_read(nanots_reader_t reader,
   try {
     nanots_callback_context ctx{callback, user_data};
     reader->reader->read(std::string(stream_tag), start_timestamp, end_timestamp,
-                         [&ctx](const uint8_t* data, size_t size, uint8_t flags,
-                                int64_t timestamp, int64_t block_sequence, const std::string& metadata) {
-                           ctx.callback(data, size, flags, timestamp,
+                         [&ctx](const uint8_t* data, size_t size, uint32_t flags,
+                                int64_t timestamp, int64_t secondary_key,
+                                int64_t block_sequence, const std::string& metadata) {
+                           ctx.callback(data, size, flags, timestamp, secondary_key,
                                         block_sequence, metadata.c_str(), ctx.user_data);
                          });
     return NANOTS_EC_OK;
@@ -2992,6 +3275,7 @@ nanots_ec_t nanots_iterator_get_current_frame(
     frame_info->size = frame.size;
     frame_info->flags = frame.flags;
     frame_info->timestamp = frame.timestamp;
+    frame_info->secondary_key = frame.secondary_key;
     frame_info->block_sequence = frame.block_sequence;
     return NANOTS_EC_OK;
   } catch (const nanots_exception& e) {
@@ -3060,6 +3344,37 @@ nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
   } catch (...) {
     fprintf(stderr,"Exception in nanots_iterator_find\n");
     return NANOTS_EC_UNKNOWN;
+  }
+}
+
+nanots_ec_t nanots_iterator_find_by_secondary_key(nanots_iterator_t iterator,
+                                                  int64_t secondary_key) {
+  if (!iterator || !iterator->iterator) {
+    return NANOTS_EC_INVALID_ARGUMENT;
+  }
+
+  try {
+    bool found = iterator->iterator->find_by_secondary_key(secondary_key);
+    return found ? NANOTS_EC_OK : NANOTS_EC_INVALID_ARGUMENT;
+  } catch (const nanots_exception& e) {
+    return e.get_ec();
+  } catch (const std::exception& e) {
+    fprintf(stderr,"Exception in nanots_iterator_find_by_secondary_key: %s\n", e.what());
+    return NANOTS_EC_UNKNOWN;
+  } catch (...) {
+    fprintf(stderr,"Exception in nanots_iterator_find_by_secondary_key\n");
+    return NANOTS_EC_UNKNOWN;
+  }
+}
+
+int nanots_iterator_has_secondary_key(nanots_iterator_t iterator) {
+  if (!iterator || !iterator->iterator) {
+    return 0;
+  }
+  try {
+    return iterator->iterator->has_secondary_key() ? 1 : 0;
+  } catch (...) {
+    return 0;
   }
 }
 

--- a/amalgamated_src/nanots.h
+++ b/amalgamated_src/nanots.h
@@ -390,7 +390,11 @@ enum nanots_ec_t {
   NANOTS_EC_UNABLE_TO_ALLOCATE_FILE = 10,
   NANOTS_EC_INVALID_ARGUMENT = 11,
   NANOTS_EC_UNKNOWN = 12,
-  NANOTS_EC_NOT_FOUND = 13
+  NANOTS_EC_NOT_FOUND = 13,
+  NANOTS_EC_BAD_MAGIC = 14,
+  NANOTS_EC_BAD_VERSION = 15,
+  NANOTS_EC_SECONDARY_KEY_MISMATCH = 16,
+  NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY = 17
 };
 
 }
@@ -415,26 +419,79 @@ private:
   int _line;
 };
 
+// --- On-disk format version 2 -------------------------------------------
+// File magic: ASCII "NTS\0". Legacy v1 files had block_size (always a
+// multiple of 65536) at offset 0, which can never collide with this magic
+// in its low byte ('N' = 0x4E), so the sniff is unambiguous.
+#define NANOTS_FILE_MAGIC "NTS\0"
+#define NANOTS_FILE_MAGIC_LEN 4
+#define NANOTS_FORMAT_VERSION 2
+
 #define FILE_HEADER_BLOCK_SIZE 65536
-// 8 + 4 + 4 bytes (with padding)
+// File header field offsets (within the first 64 KB; rest is reserved):
+//   0  : magic[4]                = "NTS\0"
+//   4  : format_version (u16)    = 2
+//   6  : header_size    (u16)    = bytes actually used (>= 32)
+//   8  : block_size     (u32)
+//   12 : n_blocks       (u32; 0 = growable)
+//   16 : max_blocks     (u32; growable cap, 0 = unbounded)
+//   20 : flags          (u32; reserved, currently 0)
+//   24 : feature_bits   (u64; bit 0 = secondary_key bit reserved for future
+//                       per-file features. Per-stream secondary-key opt-in
+//                       is recorded in segments.has_secondary_key.)
+//   32 : reserved (zeroed)
+#define FILE_HEADER_MAGIC_OFFSET     0
+#define FILE_HEADER_VERSION_OFFSET   4
+#define FILE_HEADER_HSIZE_OFFSET     6
+#define FILE_HEADER_BLOCK_SIZE_OFFSET 8
+#define FILE_HEADER_N_BLOCKS_OFFSET  12
+#define FILE_HEADER_MAX_BLOCKS_OFFSET 16
+#define FILE_HEADER_FLAGS_OFFSET     20
+#define FILE_HEADER_FEATURES_OFFSET  24
+#define FILE_HEADER_USED_BYTES       32
+
+// 8 + 4 + 4 bytes. block_feature_bits (was 'reserved') is repurposed as
+// per-block feature flags for future use; currently always 0.
 #define BLOCK_HEADER_SIZE 16
-// 8 + 8 bytes
-#define INDEX_ENTRY_SIZE 16
-// 16 + 1 + 4 bytes
-#define FRAME_HEADER_SIZE 21
-#define FRAME_UUID_OFFSET 0
-#define FRAME_SIZE_OFFSET 16
-#define FRAME_FLAGS_OFFSET 20
+
+// v2 index entry: 8 + 8 + 8 + 8 = 32 bytes.
+//   0  : timestamp     (int64)
+//   8  : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the stream has none)
+//   16 : offset        (uint64; byte offset of frame in block)
+//   24 : reserved      (uint64; zeroed)
+#define INDEX_ENTRY_SIZE 32
+#define INDEX_ENTRY_TS_OFFSET      0
+#define INDEX_ENTRY_SECKEY_OFFSET  8
+#define INDEX_ENTRY_OFFSET_OFFSET 16
+#define INDEX_ENTRY_RESERVED_OFFSET 24
+
+// v2 frame header: 16 + 8 + 4 + 4 = 32 bytes (8-byte aligned, payload at +32).
+//   0  : uuid[16]
+//   16 : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the stream has none)
+//   24 : size          (uint32)
+//   28 : flags         (uint32 — widened from u8 in v2)
+#define FRAME_HEADER_SIZE 32
+#define FRAME_UUID_OFFSET        0
+#define FRAME_SECKEY_OFFSET     16
+#define FRAME_SIZE_OFFSET       24
+#define FRAME_FLAGS_OFFSET      28
+
+// Sentinel for "no secondary key on this frame". Streams either always have
+// one or never have one; the choice is fixed at the first write into the
+// stream and stored in segments.has_secondary_key.
+#define NANOTS_SEC_KEY_UNSET INT64_MIN
 
 struct block_header {
   int64_t block_start_timestamp{0};
   uint32_t n_valid_indexes{0};
-  uint32_t reserved{0};
+  uint32_t block_feature_bits{0};
 };
 
 struct index_entry {
-  int64_t timestamp;
-  uint32_t offset;
+  int64_t timestamp{0};
+  int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
+  uint64_t offset{0};
+  uint64_t reserved{0};
 };
 
 struct block {
@@ -447,6 +504,10 @@ struct segment {
   std::string stream_tag;
   std::string metadata;
   int64_t sequence{0};
+  // True if every write into this segment must include a secondary key.
+  // Locked at segment creation time and (for the stream as a whole) recorded
+  // on the first segment created for that stream tag — see _db_create_segment.
+  bool has_secondary_key{false};
 };
 
 struct segment_block {
@@ -457,6 +518,8 @@ struct segment_block {
   int64_t block_idx{0};
   int64_t start_timestamp{0};
   int64_t end_timestamp{0};
+  int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+  int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
   uint8_t uuid[16];
 };
 
@@ -597,6 +660,7 @@ struct NANOTS_API write_context final {
   std::string metadata;
   std::string stream_tag;
   std::optional<int64_t> last_timestamp;
+  std::optional<int64_t> last_secondary_key;
   std::optional<segment> current_segment;
   std::optional<segment_block> current_block;
   nts_file file;
@@ -617,11 +681,21 @@ class NANOTS_API nanots_writer {
   write_context create_write_context(const std::string& stream_tag,
                                      const std::string& metadata);
 
+  // `secondary_key` defaults to NANOTS_SEC_KEY_UNSET — pass any other int64
+  // to write into a *keyed* stream. The choice is fixed by the first write to
+  // a given stream tag; mixing keyed and unkeyed writes on the same stream is
+  // rejected with NANOTS_EC_SECONDARY_KEY_MISMATCH. Keys are strictly
+  // monotonic within a stream.
+  //
+  // Argument order: (timestamp, secondary_key) are grouped at the end as the
+  // frame's ordering keys, with flags before them so the unkeyed call shape
+  // is just write(wctx, data, size, flags, timestamp).
   void write(write_context& wctx,
              const uint8_t* data,
              size_t size,
+             uint32_t flags,
              int64_t timestamp,
-             uint8_t flags);
+             int64_t secondary_key = NANOTS_SEC_KEY_UNSET);
 
   static void free_blocks(const std::string& file_name,
                           const std::string& stream_tag,
@@ -710,12 +784,15 @@ class NANOTS_API nanots_reader {
   nanots_reader& operator=(nanots_reader&&) = default;
   ~nanots_reader() = default;
 
+  // Callback signature is:
+  //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
+  // `secondary_key` is NANOTS_SEC_KEY_UNSET for streams that don't use one.
   void read(
       const std::string& stream_tag,
       int64_t start_timestamp,
       int64_t end_timestamp,
       const std::function<
-          void(const uint8_t*, size_t, uint8_t, int64_t, int64_t, const std::string&)>& callback);
+          void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback);
   
   std::vector<std::string> query_stream_tags(int64_t start_timestamp, int64_t end_timestamp);
 
@@ -739,8 +816,9 @@ class NANOTS_API nanots_reader {
 struct frame_info {
   const uint8_t* data{nullptr};
   size_t size{0};
-  uint8_t flags{0};
+  uint32_t flags{0};
   int64_t timestamp{0};
+  int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
   int64_t block_sequence{0};
 };
 
@@ -752,6 +830,9 @@ struct block_info {
   std::string uuid_hex;
   int64_t start_timestamp{0};
   int64_t end_timestamp{0};
+  int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+  int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
+  bool has_secondary_key{false};
 
   // Loaded block data
   nts_memory_map mm;
@@ -779,12 +860,17 @@ class NANOTS_API nanots_iterator {
   nanots_iterator& operator++();  // Move to next frame
   nanots_iterator& operator--();  // Move to previous frame
   bool find(int64_t timestamp);  // Find first frame >= timestamp
+  // Find first frame with secondary_key >= sec_key. Only valid on streams
+  // whose has_secondary_key == true; returns false otherwise.
+  bool find_by_secondary_key(int64_t sec_key);
   bool seek_end();               // Go to last frame
   void reset();                   // Go to first frame
 
   // Utility
   int64_t current_block_sequence() const { return _current_block_sequence; }
   const std::string& current_metadata() const;
+  // True if this stream stores a secondary key on every frame.
+  bool has_secondary_key();
 
  private:
   // In-memory index of all blocks in this stream, sorted by start_ts
@@ -798,6 +884,8 @@ class NANOTS_API nanots_iterator {
     int64_t end_ts;       // 0 = open block (currently being written)
     int64_t segment_id;
     int64_t sequence;
+    int64_t start_sk;     // NANOTS_SEC_KEY_UNSET if stream has no sec key
+    int64_t end_sk;       // 0 boundary semantics same as end_ts
   };
 
   block_info* _get_block_by_segment_and_sequence(int64_t segment_id, int64_t sequence);
@@ -806,6 +894,7 @@ class NANOTS_API nanots_iterator {
   block_info* _get_next_block();
   block_info* _get_prev_block();
   block_info* _find_block_for_timestamp(int64_t timestamp);
+  block_info* _find_block_for_secondary_key(int64_t sec_key);
 
   // Build (or rebuild) the timestamp index from SQL. _ensure_ts_index is the
   // lazy entry point used by navigation methods.
@@ -817,6 +906,10 @@ class NANOTS_API nanots_iterator {
   // block that covers ts (start_ts <= ts <= end_ts, or end_ts == 0); otherwise
   // returns the first block with start_ts >= ts.
   size_t _ts_index_find(int64_t ts) const;
+
+  // Same as _ts_index_find but searches by secondary key. Only meaningful for
+  // streams whose has_secondary_key is true.
+  size_t _ts_index_find_by_sk(int64_t sk) const;
 
   // True if _ts_index_pos matches (current_segment_id, current_block_sequence).
   bool   _ts_index_pos_is_valid() const;
@@ -832,6 +925,9 @@ class NANOTS_API nanots_iterator {
   std::string _stream_tag;
   nts_file _file;
   uint32_t _block_size;
+  // Cached from the segments row for this stream. -1 = not yet known;
+  // 0 = no, 1 = yes.
+  int _has_secondary_key_cache{-1};
 
   // Current position
   int64_t _current_block_sequence;
@@ -896,15 +992,17 @@ typedef struct {
 typedef struct {
   const uint8_t* data;
   size_t size;
-  uint8_t flags;
+  uint32_t flags;
   int64_t timestamp;
+  int64_t secondary_key;
   int64_t block_sequence;
 } nanots_frame_info_t;
 
 typedef void (*nanots_read_callback_t)(const uint8_t* data,
                                        size_t size,
-                                       uint8_t flags,
+                                       uint32_t flags,
                                        int64_t timestamp,
+                                       int64_t secondary_key,
                                        int64_t block_sequence,
                                        const char* metadata,
                                        void* user_data);
@@ -924,12 +1022,19 @@ NANOTS_API nanots_write_context_t nanots_writer_create_context(nanots_writer_t w
 
 NANOTS_API void nanots_write_context_destroy(nanots_write_context_t context);
 
+// Pass NANOTS_SEC_KEY_UNSET (INT64_MIN) for `secondary_key` to write into
+// a stream without a secondary key. The first write to a stream fixes the
+// choice; mixing yields NANOTS_EC_SECONDARY_KEY_MISMATCH.
+//
+// Argument order mirrors the C++ method: flags, then timestamp, then the
+// optional secondary key. The C ABI has no defaults — pass all 7 args.
 NANOTS_API nanots_ec_t nanots_writer_write(nanots_writer_t writer,
                                     nanots_write_context_t context,
                                     const uint8_t* data,
                                     size_t size,
+                                    uint32_t flags,
                                     int64_t timestamp,
-                                    uint8_t flags);
+                                    int64_t secondary_key);
 
 NANOTS_API nanots_ec_t nanots_writer_free_blocks(const char* file_name,
                                       const char* stream_tag,
@@ -981,6 +1086,14 @@ NANOTS_API nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator);
 
 NANOTS_API nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
                                      int64_t timestamp);
+
+// Returns NANOTS_EC_INVALID_ARGUMENT if the stream has no secondary key.
+NANOTS_API nanots_ec_t nanots_iterator_find_by_secondary_key(
+    nanots_iterator_t iterator,
+    int64_t secondary_key);
+
+// 1 if this iterator's stream stores secondary keys, 0 otherwise.
+NANOTS_API int nanots_iterator_has_secondary_key(nanots_iterator_t iterator);
 
 NANOTS_API nanots_ec_t nanots_iterator_reset(nanots_iterator_t iterator);
 

--- a/amalgamated_src/nanots.h
+++ b/amalgamated_src/nanots.h
@@ -392,9 +392,11 @@ enum nanots_ec_t {
   NANOTS_EC_UNKNOWN = 12,
   NANOTS_EC_NOT_FOUND = 13,
   NANOTS_EC_BAD_MAGIC = 14,
-  NANOTS_EC_BAD_VERSION = 15,
-  NANOTS_EC_SECONDARY_KEY_MISMATCH = 16,
-  NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY = 17
+  NANOTS_EC_BAD_VERSION = 15
+  // Reserved 16-17 (previously SECONDARY_KEY_MISMATCH and
+  // NON_MONOTONIC_SECONDARY_KEY). Composite-key semantics fold both into
+  // NANOTS_EC_NON_MONOTONIC_TIMESTAMP, which now means "composite (ts,
+  // sec_key) is not strictly greater than the previous frame's composite."
 };
 
 }
@@ -504,10 +506,6 @@ struct segment {
   std::string stream_tag;
   std::string metadata;
   int64_t sequence{0};
-  // True if every write into this segment must include a secondary key.
-  // Locked at segment creation time and (for the stream as a whole) recorded
-  // on the first segment created for that stream tag — see _db_create_segment.
-  bool has_secondary_key{false};
 };
 
 struct segment_block {
@@ -681,15 +679,14 @@ class NANOTS_API nanots_writer {
   write_context create_write_context(const std::string& stream_tag,
                                      const std::string& metadata);
 
-  // `secondary_key` defaults to NANOTS_SEC_KEY_UNSET — pass any other int64
-  // to write into a *keyed* stream. The choice is fixed by the first write to
-  // a given stream tag; mixing keyed and unkeyed writes on the same stream is
-  // rejected with NANOTS_EC_SECONDARY_KEY_MISMATCH. Keys are strictly
-  // monotonic within a stream.
-  //
-  // Argument order: (timestamp, secondary_key) are grouped at the end as the
-  // frame's ordering keys, with flags before them so the unkeyed call shape
-  // is just write(wctx, data, size, flags, timestamp).
+  // Frames are ordered by the COMPOSITE (timestamp, secondary_key) — that
+  // pair must be strictly greater than the previous frame's composite. So:
+  //   - timestamp may repeat; secondary_key must then strictly increase
+  //   - if timestamp strictly increases, secondary_key may be anything
+  // Default secondary_key = NANOTS_SEC_KEY_UNSET (= INT64_MIN) — the smallest
+  // possible value, equivalent to "no tiebreaker." A stream that always
+  // writes with the default gets the classic "timestamp strictly monotonic"
+  // behavior because (t, MIN) > (last_t, MIN) iff t > last_t.
   void write(write_context& wctx,
              const uint8_t* data,
              size_t size,
@@ -786,7 +783,8 @@ class NANOTS_API nanots_reader {
 
   // Callback signature is:
   //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
-  // `secondary_key` is NANOTS_SEC_KEY_UNSET for streams that don't use one.
+  // `secondary_key` is NANOTS_SEC_KEY_UNSET for frames whose writer didn't
+  // supply one.
   void read(
       const std::string& stream_tag,
       int64_t start_timestamp,
@@ -832,7 +830,6 @@ struct block_info {
   int64_t end_timestamp{0};
   int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
   int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
-  bool has_secondary_key{false};
 
   // Loaded block data
   nts_memory_map mm;
@@ -859,18 +856,21 @@ class NANOTS_API nanots_iterator {
   // Navigation
   nanots_iterator& operator++();  // Move to next frame
   nanots_iterator& operator--();  // Move to previous frame
-  bool find(int64_t timestamp);  // Find first frame >= timestamp
-  // Find first frame with secondary_key >= sec_key. Only valid on streams
-  // whose has_secondary_key == true; returns false otherwise.
-  bool find_by_secondary_key(int64_t sec_key);
+
+  // Find the first frame whose composite (timestamp, secondary_key) is >=
+  // the requested composite. Pass `secondary_key` to seek to a specific
+  // tiebroken position; omit it (defaults to NANOTS_SEC_KEY_UNSET) to land
+  // on the first frame at the requested timestamp regardless of sec_key —
+  // because INT64_MIN is the smallest possible sec_key.
+  bool find(int64_t timestamp,
+            int64_t secondary_key = NANOTS_SEC_KEY_UNSET);
+
   bool seek_end();               // Go to last frame
   void reset();                   // Go to first frame
 
   // Utility
   int64_t current_block_sequence() const { return _current_block_sequence; }
   const std::string& current_metadata() const;
-  // True if this stream stores a secondary key on every frame.
-  bool has_secondary_key();
 
  private:
   // In-memory index of all blocks in this stream, sorted by start_ts
@@ -893,8 +893,7 @@ class NANOTS_API nanots_iterator {
   block_info* _get_last_block();
   block_info* _get_next_block();
   block_info* _get_prev_block();
-  block_info* _find_block_for_timestamp(int64_t timestamp);
-  block_info* _find_block_for_secondary_key(int64_t sec_key);
+  block_info* _find_block_for_composite(int64_t timestamp, int64_t sec_key);
 
   // Build (or rebuild) the timestamp index from SQL. _ensure_ts_index is the
   // lazy entry point used by navigation methods.
@@ -905,11 +904,9 @@ class NANOTS_API nanots_iterator {
   // _ts_index.size() if none. Matches the old SQL semantics: first prefers a
   // block that covers ts (start_ts <= ts <= end_ts, or end_ts == 0); otherwise
   // returns the first block with start_ts >= ts.
-  size_t _ts_index_find(int64_t ts) const;
-
-  // Same as _ts_index_find but searches by secondary key. Only meaningful for
-  // streams whose has_secondary_key is true.
-  size_t _ts_index_find_by_sk(int64_t sk) const;
+  // Composite lower_bound: returns the position of the first block whose
+  // (start_ts, start_sk) is >= (ts, sk), or the block that covers it.
+  size_t _ts_index_find(int64_t ts, int64_t sk) const;
 
   // True if _ts_index_pos matches (current_segment_id, current_block_sequence).
   bool   _ts_index_pos_is_valid() const;
@@ -925,9 +922,6 @@ class NANOTS_API nanots_iterator {
   std::string _stream_tag;
   nts_file _file;
   uint32_t _block_size;
-  // Cached from the segments row for this stream. -1 = not yet known;
-  // 0 = no, 1 = yes.
-  int _has_secondary_key_cache{-1};
 
   // Current position
   int64_t _current_block_sequence;
@@ -1084,16 +1078,12 @@ NANOTS_API nanots_ec_t nanots_iterator_next(nanots_iterator_t iterator);
 
 NANOTS_API nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator);
 
+// Find the first frame whose composite (timestamp, secondary_key) is >= the
+// requested composite. Pass NANOTS_SEC_KEY_UNSET for `secondary_key` to land
+// on the first frame at the requested timestamp.
 NANOTS_API nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
-                                     int64_t timestamp);
-
-// Returns NANOTS_EC_INVALID_ARGUMENT if the stream has no secondary key.
-NANOTS_API nanots_ec_t nanots_iterator_find_by_secondary_key(
-    nanots_iterator_t iterator,
-    int64_t secondary_key);
-
-// 1 if this iterator's stream stores secondary keys, 0 otherwise.
-NANOTS_API int nanots_iterator_has_secondary_key(nanots_iterator_t iterator);
+                                            int64_t timestamp,
+                                            int64_t secondary_key);
 
 NANOTS_API nanots_ec_t nanots_iterator_reset(nanots_iterator_t iterator);
 

--- a/amalgamated_src/nanots.h
+++ b/amalgamated_src/nanots.h
@@ -393,32 +393,33 @@ enum nanots_ec_t {
   NANOTS_EC_NOT_FOUND = 13,
   NANOTS_EC_BAD_MAGIC = 14,
   NANOTS_EC_BAD_VERSION = 15
-  // Reserved 16-17 (previously SECONDARY_KEY_MISMATCH and
-  // NON_MONOTONIC_SECONDARY_KEY). Composite-key semantics fold both into
-  // NANOTS_EC_NON_MONOTONIC_TIMESTAMP, which now means "composite (ts,
-  // sec_key) is not strictly greater than the previous frame's composite."
 };
 
 }
 
 class NANOTS_API nanots_exception : public std::exception {
 public:
-  nanots_exception(nanots_ec_t ec, const std::string& message, const std::string& file, int line) : _ec(ec), _message(message), _file(file), _line(line) {}
-  nanots_exception(const nanots_exception& other) = default;
-  nanots_exception& operator=(const nanots_exception& other) = default;
-  nanots_exception(nanots_exception&& other) noexcept = default;
-  nanots_exception& operator=(nanots_exception&& other) noexcept = default;
-  nanots_ec_t get_ec() const { return _ec; }
-  const char* what() const noexcept override {
-    _formatted_message = format_s("%s:%d: %d(%s)", _file.c_str(), _line, _ec, _message.c_str());
-    return _formatted_message.c_str();
-  }
+    nanots_exception(
+       nanots_ec_t ec,
+       const std::string& message,
+       const std::string& file,
+       int line
+    ) : _ec(ec), _message(message), _file(file), _line(line) {}
+    nanots_exception(const nanots_exception& other) = default;
+    nanots_exception& operator=(const nanots_exception& other) = default;
+    nanots_exception(nanots_exception&& other) noexcept = default;
+    nanots_exception& operator=(nanots_exception&& other) noexcept = default;
+    nanots_ec_t get_ec() const { return _ec; }
+    const char* what() const noexcept override {
+      _formatted_message = format_s("%s:%d: %d(%s)", _file.c_str(), _line, _ec, _message.c_str());
+      return _formatted_message.c_str();
+    }
 private:
-  nanots_ec_t _ec;
-  std::string _message;
-  mutable std::string _formatted_message;
-  std::string _file;
-  int _line;
+    nanots_ec_t _ec;
+    std::string _message;
+    mutable std::string _formatted_message;
+    std::string _file;
+    int _line;
 };
 
 // --- On-disk format version 2 -------------------------------------------
@@ -438,9 +439,8 @@ private:
 //   12 : n_blocks       (u32; 0 = growable)
 //   16 : max_blocks     (u32; growable cap, 0 = unbounded)
 //   20 : flags          (u32; reserved, currently 0)
-//   24 : feature_bits   (u64; bit 0 = secondary_key bit reserved for future
-//                       per-file features. Per-stream secondary-key opt-in
-//                       is recorded in segments.has_secondary_key.)
+//   24 : feature_bits   (u64; reserved for future per-file feature flags,
+//                       currently zero)
 //   32 : reserved (zeroed)
 #define FILE_HEADER_MAGIC_OFFSET     0
 #define FILE_HEADER_VERSION_OFFSET   4
@@ -458,7 +458,8 @@ private:
 
 // v2 index entry: 8 + 8 + 8 + 8 = 32 bytes.
 //   0  : timestamp     (int64)
-//   8  : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the stream has none)
+//   8  : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the writer didn't
+//                       supply one — used as the composite tiebreaker)
 //   16 : offset        (uint64; byte offset of frame in block)
 //   24 : reserved      (uint64; zeroed)
 #define INDEX_ENTRY_SIZE 32
@@ -469,7 +470,8 @@ private:
 
 // v2 frame header: 16 + 8 + 4 + 4 = 32 bytes (8-byte aligned, payload at +32).
 //   0  : uuid[16]
-//   16 : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the stream has none)
+//   16 : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the writer didn't
+//                       supply one)
 //   24 : size          (uint32)
 //   28 : flags         (uint32 — widened from u8 in v2)
 #define FRAME_HEADER_SIZE 32
@@ -478,47 +480,50 @@ private:
 #define FRAME_SIZE_OFFSET       24
 #define FRAME_FLAGS_OFFSET      28
 
-// Sentinel for "no secondary key on this frame". Streams either always have
-// one or never have one; the choice is fixed at the first write into the
-// stream and stored in segments.has_secondary_key.
+// Default tiebreaker value for callers that don't supply a real secondary
+// key. INT64_MIN is the smallest possible int64, so under the composite
+// (timestamp, secondary_key) ordering this acts as "smaller than any real
+// key" — i.e. a stream that always passes this sentinel sees the classic
+// "timestamp strictly monotonic" rule. Any other int64 (including 0) is a
+// real key and participates in the tiebreaker.
 #define NANOTS_SEC_KEY_UNSET INT64_MIN
 
 struct block_header {
-  int64_t block_start_timestamp{0};
-  uint32_t n_valid_indexes{0};
-  uint32_t block_feature_bits{0};
+    int64_t block_start_timestamp{0};
+    uint32_t n_valid_indexes{0};
+    uint32_t block_feature_bits{0};
 };
 
 struct index_entry {
-  int64_t timestamp{0};
-  int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
-  uint64_t offset{0};
-  uint64_t reserved{0};
+    int64_t timestamp{0};
+    int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
+    uint64_t offset{0};
+    uint64_t reserved{0};
 };
 
 struct block {
-  int64_t id{0};
-  int64_t idx{0};
+    int64_t id{0};
+    int64_t idx{0};
 };
 
 struct segment {
-  int64_t id{0};
-  std::string stream_tag;
-  std::string metadata;
-  int64_t sequence{0};
+    int64_t id{0};
+    std::string stream_tag;
+    std::string metadata;
+    int64_t sequence{0};
 };
 
 struct segment_block {
-  int64_t id{0};
-  int64_t segment_id{0};
-  int64_t sequence{0};
-  int64_t block_id{0};
-  int64_t block_idx{0};
-  int64_t start_timestamp{0};
-  int64_t end_timestamp{0};
-  int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
-  int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
-  uint8_t uuid[16];
+    int64_t id{0};
+    int64_t segment_id{0};
+    int64_t sequence{0};
+    int64_t block_id{0};
+    int64_t block_idx{0};
+    int64_t start_timestamp{0};
+    int64_t end_timestamp{0};
+    int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
+    uint8_t uuid[16];
 };
 
 // ---------------------------------------------------------------------------
@@ -537,43 +542,45 @@ struct segment_block {
 // Within a single process only. Cross-process readers are not protected.
 //
 class NANOTS_API nanots_epoch_registry {
- public:
-  static constexpr uint64_t INACTIVE = UINT64_MAX;
+public:
+    static constexpr uint64_t INACTIVE = UINT64_MAX;
 
-  struct Slot {
-    std::atomic<uint64_t> epoch{INACTIVE};
-    std::atomic<int64_t>  heartbeat_us{0};
-  };
+    struct Slot {
+      std::atomic<uint64_t> epoch{INACTIVE};
+      std::atomic<int64_t> heartbeat_us{0};
+    };
 
-  // Hot-path operations.
-  uint64_t global_epoch_load() const {
-    return _global_epoch.load(std::memory_order_acquire);
-  }
-  uint64_t global_epoch_bump() {
-    return _global_epoch.fetch_add(1, std::memory_order_release);
-  }
+    // Hot-path operations.
+    uint64_t global_epoch_load() const {
+      return _global_epoch.load(std::memory_order_acquire);
+    }
 
-  // Returns true if no active slot's epoch is <= retired_epoch. Slots whose
-  // heartbeat is older than NANOTS_HEARTBEAT_TIMEOUT_US are treated as dead
-  // and ignored.
-  bool can_recycle(uint64_t retired_epoch, int64_t now_us) const;
+    uint64_t global_epoch_bump() {
+      return _global_epoch.fetch_add(1, std::memory_order_release);
+    }
 
-  // Accessor for slot_guard.
-  Slot& slot(uint32_t id);
+    // Returns true if no active slot's epoch is <= retired_epoch. Slots whose
+    // heartbeat is older than NANOTS_HEARTBEAT_TIMEOUT_US are treated as dead
+    // and ignored.
+    bool can_recycle(uint64_t retired_epoch, int64_t now_us) const;
 
-  // Acquire/release; called by nanots_slot_guard.
-  uint32_t acquire_slot();
-  void     release_slot(uint32_t id);
+    // Accessor for slot_guard.
+    Slot& slot(uint32_t id);
 
-  // Path-keyed singleton accessor. Same path string returns the same registry
-  // for the lifetime of any caller holding the shared_ptr.
-  static std::shared_ptr<nanots_epoch_registry> get_or_create(
-      const std::string& file_path);
+    // Acquire/release; called by nanots_slot_guard.
+    uint32_t acquire_slot();
+    void release_slot(uint32_t id);
 
- private:
-  std::atomic<uint64_t>               _global_epoch{1};
-  mutable std::mutex                  _slots_mu;
-  std::vector<std::unique_ptr<Slot>>  _slots;
+    // Path-keyed singleton accessor. Same path string returns the same registry
+    // for the lifetime of any caller holding the shared_ptr.
+    static std::shared_ptr<nanots_epoch_registry> get_or_create(
+        const std::string& file_path
+    );
+
+private:
+    std::atomic<uint64_t> _global_epoch{1};
+    mutable std::mutex _slots_mu;
+    std::vector<std::unique_ptr<Slot>> _slots;
 };
 
 // Heartbeat timeout: a slot whose last heartbeat is older than this is
@@ -593,28 +600,28 @@ constexpr int64_t NANOTS_HEARTBEAT_TIMEOUT_US = 60LL * 1000 * 1000;  // 60s
 // Move-only.
 //
 class NANOTS_API nanots_slot_guard {
- public:
-  nanots_slot_guard() = default;
-  explicit nanots_slot_guard(std::shared_ptr<nanots_epoch_registry> registry);
-  ~nanots_slot_guard();
+public:
+    nanots_slot_guard() = default;
+    explicit nanots_slot_guard(std::shared_ptr<nanots_epoch_registry> registry);
+    ~nanots_slot_guard();
 
-  nanots_slot_guard(const nanots_slot_guard&)            = delete;
-  nanots_slot_guard& operator=(const nanots_slot_guard&) = delete;
-  nanots_slot_guard(nanots_slot_guard&& other) noexcept;
-  nanots_slot_guard& operator=(nanots_slot_guard&& other) noexcept;
+    nanots_slot_guard(const nanots_slot_guard&)            = delete;
+    nanots_slot_guard& operator=(const nanots_slot_guard&) = delete;
+    nanots_slot_guard(nanots_slot_guard&& other) noexcept;
+    nanots_slot_guard& operator=(nanots_slot_guard&& other) noexcept;
 
-  // Publishes the latest global_epoch to our slot and updates the heartbeat.
-  // Call at the start of every iterator operation. No-op if !active().
-  void op_begin();
+    // Publishes the latest global_epoch to our slot and updates the heartbeat.
+    // Call at the start of every iterator operation. No-op if !active().
+    void op_begin();
 
-  // True if this guard owns a slot.
-  bool active() const { return _slot_id != UINT32_MAX; }
+    // True if this guard owns a slot.
+    bool active() const { return _slot_id != UINT32_MAX; }
 
- private:
-  void _release() noexcept;
+private:
+    void _release() noexcept;
 
-  std::shared_ptr<nanots_epoch_registry> _registry;
-  uint32_t                                _slot_id{UINT32_MAX};
+    std::shared_ptr<nanots_epoch_registry> _registry;
+    uint32_t _slot_id{UINT32_MAX};
 };
 
 // ---------------------------------------------------------------------------
@@ -631,341 +638,386 @@ class NANOTS_API nanots_slot_guard {
 // assertions, etc.) without churning all the call sites again.
 //
 class NANOTS_API nanots_op_scope {
- public:
-  explicit nanots_op_scope(nanots_slot_guard& guard) : _guard(guard) {
-    _guard.op_begin();
-  }
-  ~nanots_op_scope() = default;
+public:
+    explicit nanots_op_scope(nanots_slot_guard& guard) : _guard(guard) {
+      _guard.op_begin();
+    }
+    ~nanots_op_scope() = default;
 
-  nanots_op_scope(const nanots_op_scope&)            = delete;
-  nanots_op_scope& operator=(const nanots_op_scope&) = delete;
-  nanots_op_scope(nanots_op_scope&&)                 = delete;
-  nanots_op_scope& operator=(nanots_op_scope&&)      = delete;
+    nanots_op_scope(const nanots_op_scope&)            = delete;
+    nanots_op_scope& operator=(const nanots_op_scope&) = delete;
+    nanots_op_scope(nanots_op_scope&&)                 = delete;
+    nanots_op_scope& operator=(nanots_op_scope&&)      = delete;
 
- private:
-  nanots_slot_guard& _guard;
+private:
+    nanots_slot_guard& _guard;
 };
 
 struct NANOTS_API write_context final {
-  write_context() = default;
-  write_context(const write_context&) = delete;
-  write_context& operator=(const write_context&) = delete;
-  write_context(write_context&& other) = default;
-  write_context& operator=(write_context&& other) = default;
+    write_context() = default;
+    write_context(const write_context&) = delete;
+    write_context& operator=(const write_context&) = delete;
+    write_context(write_context&& other) = default;
+    write_context& operator=(write_context&& other) = default;
 
-  ~write_context();
+    ~write_context();
 
-  std::string metadata;
-  std::string stream_tag;
-  std::optional<int64_t> last_timestamp;
-  std::optional<int64_t> last_secondary_key;
-  std::optional<segment> current_segment;
-  std::optional<segment_block> current_block;
-  nts_file file;
-  nts_memory_map mm;
-  std::string file_name;
-  uint32_t _block_size{0};
+    std::string metadata;
+    std::string stream_tag;
+    std::optional<int64_t> last_timestamp;
+    std::optional<int64_t> last_secondary_key;
+    std::optional<segment> current_segment;
+    std::optional<segment_block> current_block;
+    nts_file file;
+    nts_memory_map mm;
+    std::string file_name;
+    uint32_t _block_size{0};
 };
 
 class NANOTS_API nanots_writer {
  public:
-  nanots_writer(const std::string& file_name, bool auto_reclaim = false);
-  nanots_writer(const nanots_writer&) = delete;
-  nanots_writer(nanots_writer&&) = default;
-  nanots_writer& operator=(const nanots_writer&) = delete;
-  nanots_writer& operator=(nanots_writer&&) = default;
-  ~nanots_writer() = default;
+    nanots_writer(const std::string& file_name, bool auto_reclaim = false);
+    nanots_writer(const nanots_writer&) = delete;
+    nanots_writer(nanots_writer&&) = default;
+    nanots_writer& operator=(const nanots_writer&) = delete;
+    nanots_writer& operator=(nanots_writer&&) = default;
+    ~nanots_writer() = default;
 
-  write_context create_write_context(const std::string& stream_tag,
-                                     const std::string& metadata);
+    write_context create_write_context(
+        const std::string& stream_tag,
+        const std::string& metadata
+    );
 
-  // Frames are ordered by the COMPOSITE (timestamp, secondary_key) — that
-  // pair must be strictly greater than the previous frame's composite. So:
-  //   - timestamp may repeat; secondary_key must then strictly increase
-  //   - if timestamp strictly increases, secondary_key may be anything
-  // Default secondary_key = NANOTS_SEC_KEY_UNSET (= INT64_MIN) — the smallest
-  // possible value, equivalent to "no tiebreaker." A stream that always
-  // writes with the default gets the classic "timestamp strictly monotonic"
-  // behavior because (t, MIN) > (last_t, MIN) iff t > last_t.
-  void write(write_context& wctx,
-             const uint8_t* data,
-             size_t size,
-             uint32_t flags,
-             int64_t timestamp,
-             int64_t secondary_key = NANOTS_SEC_KEY_UNSET);
+    // Frames are ordered by the COMPOSITE (timestamp, secondary_key) — that
+    // pair must be strictly greater than the previous frame's composite. So:
+    //   - timestamp may repeat; secondary_key must then strictly increase
+    //   - if timestamp strictly increases, secondary_key may be anything
+    // Default secondary_key = NANOTS_SEC_KEY_UNSET (= INT64_MIN) — the smallest
+    // possible value, equivalent to "no tiebreaker." A stream that always
+    // writes with the default gets the classic "timestamp strictly monotonic"
+    // behavior because (t, MIN) > (last_t, MIN) iff t > last_t.
+    void write(
+        write_context& wctx,
+        const uint8_t* data,
+        size_t size,
+        uint32_t flags,
+        int64_t timestamp,
+        int64_t secondary_key = NANOTS_SEC_KEY_UNSET
+    );
 
-  static void free_blocks(const std::string& file_name,
-                          const std::string& stream_tag,
-                          int64_t start_timestamp,
-                          int64_t end_timestamp);
+    // Free every block in this stream that falls entirely within the
+    // composite window [(start_ts, start_sk), (end_ts, end_sk)]. Pass
+    // NANOTS_SEC_KEY_UNSET for start_secondary_key and INT64_MAX for
+    // end_secondary_key to ignore the sec_key axis (the classic
+    // timestamp-only deletion).
+    static void free_blocks(
+        const std::string& file_name,
+        const std::string& stream_tag,
+        int64_t start_timestamp,
+        int64_t start_secondary_key,
+        int64_t end_timestamp,
+        int64_t end_secondary_key
+    );
 
-  // Preallocated: fixed-size file with n_blocks slots, never grows.
-  // Pass n_blocks == 0 to create a growable file (see allocate_growable).
-  static void allocate(const std::string& file_name,
-                       uint32_t block_size,
-                       uint32_t n_blocks);
+    // Preallocated: fixed-size file with n_blocks slots, never grows.
+    // Pass n_blocks == 0 to create a growable file (see allocate_growable).
+    static void allocate(
+        const std::string& file_name,
+        uint32_t block_size,
+        uint32_t n_blocks
+    );
 
-  // Growable: file starts at just the header and extends on demand.
-  // max_blocks == 0 means unbounded (grow until disk is full).
-  static void allocate_growable(const std::string& file_name,
-                                uint32_t block_size,
-                                uint32_t max_blocks = 0);
+    // Growable: file starts at just the header and extends on demand.
+    // max_blocks == 0 means unbounded (grow until disk is full).
+    static void allocate_growable(
+        const std::string& file_name,
+        uint32_t block_size,
+        uint32_t max_blocks = 0
+    );
 
-  bool is_growable() const { return _n_blocks == 0; }
+    bool is_growable() const { return _n_blocks == 0; }
 
-  // Grow the file by some number of blocks (BoltDB-style: doubles up to a
-  // 1 GiB-per-grow cap, then linear). Caller must already hold a sqlite
-  // IMMEDIATE transaction. Returns the first new block (status='reserved');
-  // any extras are inserted as 'free'. Returns nullopt if max_blocks cap
-  // is already reached. Public only so _db_get_block can call it; treat as
-  // internal.
-  std::optional<block> _grow_blocks(const nts_sqlite_conn& conn);
+    // Grow the file by some number of blocks (BoltDB-style: doubles up to a
+    // 1 GiB-per-grow cap, then linear). Caller must already hold a sqlite
+    // IMMEDIATE transaction. Returns the first new block (status='reserved');
+    // any extras are inserted as 'free'. Returns nullopt if max_blocks cap
+    // is already reached. Public only so _db_get_block can call it; treat as
+    // internal.
+    std::optional<block> _grow_blocks(const nts_sqlite_conn& conn);
 
  private:
 
-  // EBR limbo: blocks the writer has retired (catalog ops done, but bytes
-  // not yet overwritten). _limbo entries that have cleared EBR safety get
-  // migrated to _ready, ready to be consumed by the next acquire.
-  struct LimboEntry {
-    int64_t  block_id;
-    int64_t  block_idx;
-    uint64_t retired_epoch;
-  };
+    // EBR limbo: blocks the writer has retired (catalog ops done, but bytes
+    // not yet overwritten). _limbo entries that have cleared EBR safety get
+    // migrated to _ready, ready to be consumed by the next acquire.
+    struct LimboEntry {
+        int64_t  block_id;
+        int64_t  block_idx;
+        uint64_t retired_epoch;
+    };
 
-  // Cap on outstanding limbo entries. If a long-stalled reader prevents
-  // any limbo entry from clearing, retire calls throw rather than grow
-  // unboundedly.
-  static constexpr size_t LIMBO_MAX_ENTRIES = 1024;
+    // Cap on outstanding limbo entries. If a long-stalled reader prevents
+    // any limbo entry from clearing, retire calls throw rather than grow
+    // unboundedly.
+    static constexpr size_t LIMBO_MAX_ENTRIES = 1024;
 
-  // Top-level block acquisition under EBR. Tries (1) ready queue, (2) free
-  // block, (3) growable extension, (4) retire-into-limbo + ready queue with
-  // bounded retries. Returned block is always safe to pass through
-  // _recycle_block: either truly free (already zeroed), freshly grown, or
-  // an EBR-cleared retired block.
-  block _acquire_writable_block(const nts_sqlite_conn& conn);
+    // Top-level block acquisition under EBR. Tries (1) ready queue, (2) free
+    // block, (3) growable extension, (4) retire-into-limbo + ready queue with
+    // bounded retries. Returned block is always safe to pass through
+    // _recycle_block: either truly free (already zeroed), freshly grown, or
+    // an EBR-cleared retired block.
+    block _acquire_writable_block(const nts_sqlite_conn& conn);
 
-  // Move limbo entries that have cleared EBR safety into the ready queue.
-  // Caller must NOT hold _limbo_mu.
-  void _scan_limbo();
+    // Move limbo entries that have cleared EBR safety into the ready queue.
+    // Caller must NOT hold _limbo_mu.
+    void _scan_limbo();
 
-  std::string _file_name;
-  uint64_t _file_size;
-  nts_file _file;
-  nts_memory_map _file_header_mm;
-  uint8_t* _file_header_p;
-  uint32_t _block_size;
-  uint32_t _n_blocks;       // 0 == growable mode (sentinel)
-  uint32_t _max_blocks;     // growable cap; 0 == unbounded; ignored if !growable
-  bool _auto_reclaim;
-  std::set<std::string> _active_stream_tags;
+    std::string _file_name;
+    uint64_t _file_size;
+    nts_file _file;
+    nts_memory_map _file_header_mm;
+    uint8_t* _file_header_p;
+    uint32_t _block_size;
+    uint32_t _n_blocks;       // 0 == growable mode (sentinel)
+    uint32_t _max_blocks;     // growable cap; 0 == unbounded; ignored if !growable
+    bool _auto_reclaim;
+    std::set<std::string> _active_stream_tags;
 
-  // EBR state. _epoch is shared with every iterator and writer on this file.
-  std::shared_ptr<nanots_epoch_registry> _epoch;
-  std::deque<LimboEntry>                 _limbo;
-  std::deque<LimboEntry>                 _ready;
-  std::mutex                             _limbo_mu;
+    // EBR state. _epoch is shared with every iterator and writer on this file.
+    std::shared_ptr<nanots_epoch_registry> _epoch;
+    std::deque<LimboEntry> _limbo;
+    std::deque<LimboEntry> _ready;
+    std::mutex _limbo_mu;
 };
 
 struct contiguous_segment {
-  int64_t segment_id{0};
-  int64_t start_timestamp{0};
-  int64_t end_timestamp{0};
+    int64_t segment_id{0};
+    int64_t start_timestamp{0};
+    int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t end_timestamp{0};
+    int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
 };
 
 class NANOTS_API nanots_reader {
  public:
-  nanots_reader(const std::string& file_name);
-  nanots_reader(const nanots_reader&) = delete;
-  nanots_reader(nanots_reader&&) = default;
-  nanots_reader& operator=(const nanots_reader&) = delete;
-  nanots_reader& operator=(nanots_reader&&) = default;
-  ~nanots_reader() = default;
+    nanots_reader(const std::string& file_name);
+    nanots_reader(const nanots_reader&) = delete;
+    nanots_reader(nanots_reader&&) = default;
+    nanots_reader& operator=(const nanots_reader&) = delete;
+    nanots_reader& operator=(nanots_reader&&) = default;
+    ~nanots_reader() = default;
 
-  // Callback signature is:
-  //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
-  // `secondary_key` is NANOTS_SEC_KEY_UNSET for frames whose writer didn't
-  // supply one.
-  void read(
-      const std::string& stream_tag,
-      int64_t start_timestamp,
-      int64_t end_timestamp,
-      const std::function<
-          void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback);
-  
-  std::vector<std::string> query_stream_tags(int64_t start_timestamp, int64_t end_timestamp);
+    // Stream all frames whose composite (timestamp, secondary_key) falls
+    // within [(start_ts, start_sk), (end_ts, end_sk)] inclusive. Pass
+    // NANOTS_SEC_KEY_UNSET for start_secondary_key and INT64_MAX for
+    // end_secondary_key to ignore the sec_key axis.
+    //
+    // Callback signature is:
+    //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
+    // `secondary_key` is NANOTS_SEC_KEY_UNSET for frames whose writer didn't
+    // supply one.
+    void read(
+        const std::string& stream_tag,
+        int64_t start_timestamp,
+        int64_t start_secondary_key,
+        int64_t end_timestamp,
+        int64_t end_secondary_key,
+        const std::function<
+            void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback
+    );
 
-  std::vector<contiguous_segment> query_contiguous_segments(
-      const std::string& stream_tag,
-      int64_t start_timestamp,
-      int64_t end_timestamp);
+    // Distinct stream tags that have any block overlapping the composite
+    // window. Use NANOTS_SEC_KEY_UNSET / INT64_MAX for sec_key bounds to
+    // ignore that axis.
+    std::vector<std::string> query_stream_tags(
+        int64_t start_timestamp,
+        int64_t start_secondary_key,
+        int64_t end_timestamp,
+        int64_t end_secondary_key
+    );
+
+    // Contiguous runs of blocks for this stream within the composite window.
+    // Use NANOTS_SEC_KEY_UNSET / INT64_MAX for sec_key bounds to ignore
+    // that axis.
+    std::vector<contiguous_segment> query_contiguous_segments(
+        const std::string& stream_tag,
+        int64_t start_timestamp,
+        int64_t start_secondary_key,
+        int64_t end_timestamp,
+        int64_t end_secondary_key
+    );
 
  private:
-  std::string _file_name;
-  nts_file _file;
-  uint32_t _block_size;
-  uint32_t _n_blocks;
+    std::string _file_name;
+    nts_file _file;
+    uint32_t _block_size;
+    uint32_t _n_blocks;
 
-  // EBR slot. Acquired on construction, released on destruction. read() opens
-  // a critical section for its duration so the writer cannot overwrite block
-  // bytes while the callback is dereferencing them.
-  nanots_slot_guard _slot_guard;
+    // EBR slot. Acquired on construction, released on destruction. read() opens
+    // a critical section for its duration so the writer cannot overwrite block
+    // bytes while the callback is dereferencing them.
+    nanots_slot_guard _slot_guard;
 };
 
 struct frame_info {
-  const uint8_t* data{nullptr};
-  size_t size{0};
-  uint32_t flags{0};
-  int64_t timestamp{0};
-  int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
-  int64_t block_sequence{0};
+    const uint8_t* data{nullptr};
+    size_t size{0};
+    uint32_t flags{0};
+    int64_t timestamp{0};
+    int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t block_sequence{0};
 };
 
 struct block_info {
-  int64_t block_idx{0};
-  int64_t block_sequence{0};
-  int64_t segment_id{0};
-  std::string metadata;
-  std::string uuid_hex;
-  int64_t start_timestamp{0};
-  int64_t end_timestamp{0};
-  int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
-  int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t block_idx{0};
+    int64_t block_sequence{0};
+    int64_t segment_id{0};
+    std::string metadata;
+    std::string uuid_hex;
+    int64_t start_timestamp{0};
+    int64_t end_timestamp{0};
+    int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
 
-  // Loaded block data
-  nts_memory_map mm;
-  uint8_t* block_p{nullptr};
-  uint32_t n_valid_indexes{0};
-  uint8_t uuid[16];
-  bool is_loaded{false};
+    // Loaded block data
+    nts_memory_map mm;
+    uint8_t* block_p{nullptr};
+    uint32_t n_valid_indexes{0};
+    uint8_t uuid[16];
+    bool is_loaded{false};
 };
 
 class NANOTS_API nanots_iterator {
  public:
-  nanots_iterator(const std::string& file_name, const std::string& stream_tag);
-  nanots_iterator(const nanots_iterator&) = delete;
-  nanots_iterator(nanots_iterator&&) = default;
-  nanots_iterator& operator=(const nanots_iterator&) = delete;
-  nanots_iterator& operator=(nanots_iterator&&) = default;
-  ~nanots_iterator() = default;
+    nanots_iterator(
+        const std::string& file_name,
+        const std::string& stream_tag
+    );
+    nanots_iterator(const nanots_iterator&) = delete;
+    nanots_iterator(nanots_iterator&&) = default;
+    nanots_iterator& operator=(const nanots_iterator&) = delete;
+    nanots_iterator& operator=(nanots_iterator&&) = default;
+    ~nanots_iterator() = default;
 
-  // Iterator interface
-  bool valid() const { return _valid; }
-  const frame_info& operator*() const { return _current_frame; }
-  const frame_info* operator->() const { return &_current_frame; }
+    // Iterator interface
+    bool valid() const { return _valid; }
+    const frame_info& operator*() const { return _current_frame; }
+    const frame_info* operator->() const { return &_current_frame; }
 
-  // Navigation
-  nanots_iterator& operator++();  // Move to next frame
-  nanots_iterator& operator--();  // Move to previous frame
+    // Navigation
+    nanots_iterator& operator++();  // Move to next frame
+    nanots_iterator& operator--();  // Move to previous frame
 
-  // Find the first frame whose composite (timestamp, secondary_key) is >=
-  // the requested composite. Pass `secondary_key` to seek to a specific
-  // tiebroken position; omit it (defaults to NANOTS_SEC_KEY_UNSET) to land
-  // on the first frame at the requested timestamp regardless of sec_key —
-  // because INT64_MIN is the smallest possible sec_key.
-  bool find(int64_t timestamp,
-            int64_t secondary_key = NANOTS_SEC_KEY_UNSET);
+    // Find the first frame whose composite (timestamp, secondary_key) is >=
+    // the requested composite. Pass `secondary_key` to seek to a specific
+    // tiebroken position; omit it (defaults to NANOTS_SEC_KEY_UNSET) to land
+    // on the first frame at the requested timestamp regardless of sec_key —
+    // because INT64_MIN is the smallest possible sec_key.
+    bool find(int64_t timestamp,
+              int64_t secondary_key = NANOTS_SEC_KEY_UNSET
+    );
 
-  bool seek_end();               // Go to last frame
-  void reset();                   // Go to first frame
+    bool seek_end();               // Go to last frame
+    void reset();                   // Go to first frame
 
-  // Utility
-  int64_t current_block_sequence() const { return _current_block_sequence; }
-  const std::string& current_metadata() const;
+    // Utility
+    int64_t current_block_sequence() const { return _current_block_sequence; }
+    const std::string& current_metadata() const;
 
  private:
-  // In-memory index of all blocks in this stream, sorted by start_ts
-  // (equivalently by (segment_id, sequence) since both are monotonic for a
-  // given stream). Built lazily on first navigation operation; refreshed when
-  // a stale entry is detected or when navigation runs off the cached end.
-  // Replaces per-op SQL queries in _find_block_for_timestamp /
-  // _get_first/last/next/prev_block with in-memory binary search.
-  struct BlockRange {
-    int64_t start_ts;
-    int64_t end_ts;       // 0 = open block (currently being written)
-    int64_t segment_id;
-    int64_t sequence;
-    int64_t start_sk;     // NANOTS_SEC_KEY_UNSET if stream has no sec key
-    int64_t end_sk;       // 0 boundary semantics same as end_ts
-  };
+    // In-memory index of all blocks in this stream, sorted by start_ts
+    // (equivalently by (segment_id, sequence) since both are monotonic for a
+    // given stream). Built lazily on first navigation operation; refreshed when
+    // a stale entry is detected or when navigation runs off the cached end.
+    // Replaces per-op SQL queries in _find_block_for_timestamp /
+    // _get_first/last/next/prev_block with in-memory binary search.
+    struct BlockRange {
+      int64_t start_ts;
+      int64_t end_ts;       // 0 = open block (currently being written)
+      int64_t segment_id;
+      int64_t sequence;
+      int64_t start_sk;     // NANOTS_SEC_KEY_UNSET if stream has no sec key
+      int64_t end_sk;       // 0 boundary semantics same as end_ts
+    };
 
-  block_info* _get_block_by_segment_and_sequence(int64_t segment_id, int64_t sequence);
-  block_info* _get_first_block();
-  block_info* _get_last_block();
-  block_info* _get_next_block();
-  block_info* _get_prev_block();
-  block_info* _find_block_for_composite(int64_t timestamp, int64_t sec_key);
+    block_info* _get_block_by_segment_and_sequence(int64_t segment_id, int64_t sequence);
+    block_info* _get_first_block();
+    block_info* _get_last_block();
+    block_info* _get_next_block();
+    block_info* _get_prev_block();
+    block_info* _find_block_for_composite(int64_t timestamp, int64_t sec_key);
 
-  // Build (or rebuild) the timestamp index from SQL. _ensure_ts_index is the
-  // lazy entry point used by navigation methods.
-  void   _ensure_ts_index();
-  void   _refresh_ts_index();
+    // Build (or rebuild) the timestamp index from SQL. _ensure_ts_index is the
+    // lazy entry point used by navigation methods.
+    void _ensure_ts_index();
+    void _refresh_ts_index();
 
-  // Returns the position in _ts_index of the block matching ts, or
-  // _ts_index.size() if none. Matches the old SQL semantics: first prefers a
-  // block that covers ts (start_ts <= ts <= end_ts, or end_ts == 0); otherwise
-  // returns the first block with start_ts >= ts.
-  // Composite lower_bound: returns the position of the first block whose
-  // (start_ts, start_sk) is >= (ts, sk), or the block that covers it.
-  size_t _ts_index_find(int64_t ts, int64_t sk) const;
+    // Returns the position in _ts_index of the block matching ts, or
+    // _ts_index.size() if none. Matches the old SQL semantics: first prefers a
+    // block that covers ts (start_ts <= ts <= end_ts, or end_ts == 0); otherwise
+    // returns the first block with start_ts >= ts.
+    // Composite lower_bound: returns the position of the first block whose
+    // (start_ts, start_sk) is >= (ts, sk), or the block that covers it.
+    size_t _ts_index_find(int64_t ts, int64_t sk) const;
 
-  // True if _ts_index_pos matches (current_segment_id, current_block_sequence).
-  bool   _ts_index_pos_is_valid() const;
+    // True if _ts_index_pos matches (current_segment_id, current_block_sequence).
+    bool _ts_index_pos_is_valid() const;
 
-  // Linear search _ts_index for (current_segment_id, current_block_sequence)
-  // and update _ts_index_pos. Returns true on success.
-  bool   _ts_index_relocate();
+    // Linear search _ts_index for (current_segment_id, current_block_sequence)
+    // and update _ts_index_pos. Returns true on success.
+    bool _ts_index_relocate();
 
-  bool _load_block_data(block_info& block);
-  bool _load_current_frame();
+    bool _load_block_data(block_info& block);
+    bool _load_current_frame();
 
-  std::string _file_name;
-  std::string _stream_tag;
-  nts_file _file;
-  uint32_t _block_size;
+    std::string _file_name;
+    std::string _stream_tag;
+    nts_file _file;
+    uint32_t _block_size;
 
-  // Current position
-  int64_t _current_block_sequence;
-  int64_t _current_segment_id;
-  size_t _current_frame_idx;
-  int64_t _current_block_start_ts;
-  int64_t _current_block_end_ts;
+    // Current position
+    int64_t _current_block_sequence;
+    int64_t _current_segment_id;
+    size_t _current_frame_idx;
+    int64_t _current_block_start_ts;
+    int64_t _current_block_end_ts;
 
-  // Cache of visited blocks (segment_id:sequence -> block_info)
-  // Using string key for simplicity: "segment_id:sequence"
-  std::unordered_map<std::string, block_info> _block_cache;
+    // Cache of visited blocks (segment_id:sequence -> block_info)
+    // Using string key for simplicity: "segment_id:sequence"
+    std::unordered_map<std::string, block_info> _block_cache;
 
-  // Timestamp index. See BlockRange above. _ts_index_pos tracks the position
-  // in _ts_index corresponding to (_current_segment_id, _current_block_sequence)
-  // so operator++/-- can advance via array indexing instead of SQL.
-  std::vector<BlockRange> _ts_index;
-  bool                    _ts_index_filled{false};
-  size_t                  _ts_index_pos{0};
+    // Timestamp index. See BlockRange above. _ts_index_pos tracks the position
+    // in _ts_index corresponding to (_current_segment_id, _current_block_sequence)
+    // so operator++/-- can advance via array indexing instead of SQL.
+    std::vector<BlockRange> _ts_index;
+    bool _ts_index_filled{false};
+    size_t _ts_index_pos{0};
 
-  // Cached current frame
-  frame_info _current_frame;
-  bool _valid;
-  bool _initialized;
+    // Cached current frame
+    frame_info _current_frame;
+    bool _valid;
+    bool _initialized;
 
-  // Lazily-initialized database connection for read operations
-  std::optional<nts_sqlite_conn> _db_conn;
-  nts_sqlite_conn& _ensure_db_connection();
+    // Lazily-initialized database connection for read operations
+    std::optional<nts_sqlite_conn> _db_conn;
+    nts_sqlite_conn& _ensure_db_connection();
 
-  // Cached prepared statements (lazily initialized on first use)
-  std::optional<nts_sqlite_stmt> _stmt_get_block_by_id;
-  std::optional<nts_sqlite_stmt> _stmt_get_first_block;
-  std::optional<nts_sqlite_stmt> _stmt_get_last_block;
-  std::optional<nts_sqlite_stmt> _stmt_next_in_segment;
-  std::optional<nts_sqlite_stmt> _stmt_next_cross_segment;
-  std::optional<nts_sqlite_stmt> _stmt_prev_in_segment;
-  std::optional<nts_sqlite_stmt> _stmt_prev_cross_segment;
-  std::optional<nts_sqlite_stmt> _stmt_find_block_containing;
-  std::optional<nts_sqlite_stmt> _stmt_find_block_ge;
+    // Cached prepared statements (lazily initialized on first use)
+    std::optional<nts_sqlite_stmt> _stmt_get_block_by_id;
+    std::optional<nts_sqlite_stmt> _stmt_get_first_block;
+    std::optional<nts_sqlite_stmt> _stmt_get_last_block;
+    std::optional<nts_sqlite_stmt> _stmt_next_in_segment;
+    std::optional<nts_sqlite_stmt> _stmt_next_cross_segment;
+    std::optional<nts_sqlite_stmt> _stmt_prev_in_segment;
+    std::optional<nts_sqlite_stmt> _stmt_prev_cross_segment;
+    std::optional<nts_sqlite_stmt> _stmt_find_block_containing;
+    std::optional<nts_sqlite_stmt> _stmt_find_block_ge;
 
-  // EBR slot. Acquired on construction, released on destruction. Each
-  // navigation operation (find, ++, --, reset, seek_end) calls op_begin()
-  // to publish the current global epoch + heartbeat. This is what permits
-  // the writer to know it's safe to physically recycle a block.
-  nanots_slot_guard _slot_guard;
+    // EBR slot. Acquired on construction, released on destruction. Each
+    // navigation operation (find, ++, --, reset, seek_end) calls op_begin()
+    // to publish the current global epoch + heartbeat. This is what permits
+    // the writer to know it's safe to physically recycle a block.
+    nanots_slot_guard _slot_guard;
 };
 
 #ifdef __cplusplus
@@ -980,7 +1032,9 @@ typedef struct nanots_iterator_handle* nanots_iterator_t;
 typedef struct {
   int64_t segment_id;
   int64_t start_timestamp;
+  int64_t start_secondary_key;
   int64_t end_timestamp;
+  int64_t end_secondary_key;
 } nanots_contiguous_segment_t;
 
 typedef struct {
@@ -992,87 +1046,129 @@ typedef struct {
   int64_t block_sequence;
 } nanots_frame_info_t;
 
-typedef void (*nanots_read_callback_t)(const uint8_t* data,
-                                       size_t size,
-                                       uint32_t flags,
-                                       int64_t timestamp,
-                                       int64_t secondary_key,
-                                       int64_t block_sequence,
-                                       const char* metadata,
-                                       void* user_data);
+typedef void (*nanots_read_callback_t)(
+    const uint8_t* data,
+    size_t size,
+    uint32_t flags,
+    int64_t timestamp,
+    int64_t secondary_key,
+    int64_t block_sequence,
+    const char* metadata,
+    void* user_data
+);
 
-NANOTS_API nanots_ec_t nanots_writer_allocate_file(const char* file_name, uint32_t block_size, uint32_t n_blocks);
+NANOTS_API nanots_ec_t nanots_writer_allocate_file(
+    const char* file_name,
+    uint32_t block_size,
+    uint32_t n_blocks
+);
 
-NANOTS_API nanots_ec_t nanots_writer_allocate_growable_file(const char* file_name, uint32_t block_size, uint32_t max_blocks);
+NANOTS_API nanots_ec_t nanots_writer_allocate_growable_file(
+    const char* file_name,
+    uint32_t block_size,
+    uint32_t max_blocks
+);
 
 // writer
-NANOTS_API nanots_writer_t nanots_writer_create(const char* file_name, int auto_reclaim);
+NANOTS_API nanots_writer_t nanots_writer_create(
+    const char* file_name,
+    int auto_reclaim
+);
 
 NANOTS_API void nanots_writer_destroy(nanots_writer_t writer);
 
-NANOTS_API nanots_write_context_t nanots_writer_create_context(nanots_writer_t writer,
-                                                    const char* stream_tag,
-                                                    const char* metadata);
+NANOTS_API nanots_write_context_t nanots_writer_create_context(
+    nanots_writer_t writer,
+    const char* stream_tag,
+    const char* metadata
+);
 
 NANOTS_API void nanots_write_context_destroy(nanots_write_context_t context);
 
 // Pass NANOTS_SEC_KEY_UNSET (INT64_MIN) for `secondary_key` to write into
-// a stream without a secondary key. The first write to a stream fixes the
-// choice; mixing yields NANOTS_EC_SECONDARY_KEY_MISMATCH.
+// a stream that doesn't use a tiebreaker. Frames are ordered by the
+// composite (timestamp, secondary_key) which must be strictly monotonic.
 //
 // Argument order mirrors the C++ method: flags, then timestamp, then the
-// optional secondary key. The C ABI has no defaults — pass all 7 args.
-NANOTS_API nanots_ec_t nanots_writer_write(nanots_writer_t writer,
-                                    nanots_write_context_t context,
-                                    const uint8_t* data,
-                                    size_t size,
-                                    uint32_t flags,
-                                    int64_t timestamp,
-                                    int64_t secondary_key);
+// secondary key. The C ABI has no defaults — pass all 7 args.
+NANOTS_API nanots_ec_t nanots_writer_write(
+    nanots_writer_t writer,
+    nanots_write_context_t context,
+    const uint8_t* data,
+    size_t size,
+    uint32_t flags,
+    int64_t timestamp,
+    int64_t secondary_key
+);
 
-NANOTS_API nanots_ec_t nanots_writer_free_blocks(const char* file_name,
-                                      const char* stream_tag,
-                                      int64_t start_timestamp,
-                                      int64_t end_timestamp);
+// Free blocks fully contained in the composite window
+// [(start_ts, start_sk), (end_ts, end_sk)]. Use NANOTS_SEC_KEY_UNSET and
+// INT64_MAX for the sec_key bounds to ignore that axis.
+NANOTS_API nanots_ec_t nanots_writer_free_blocks(
+    const char* file_name,
+    const char* stream_tag,
+    int64_t start_timestamp,
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key
+);
 
 // reader
 NANOTS_API nanots_reader_t nanots_reader_create(const char* file_name);
 
 NANOTS_API void nanots_reader_destroy(nanots_reader_t reader);
 
-NANOTS_API nanots_ec_t nanots_reader_read(nanots_reader_t reader,
-                               const char* stream_tag,
-                               int64_t start_timestamp,
-                               int64_t end_timestamp,
-                               nanots_read_callback_t callback,
-                               void* user_data);
+// Stream frames whose composite (timestamp, secondary_key) lies within
+// [(start_ts, start_sk), (end_ts, end_sk)]. Use NANOTS_SEC_KEY_UNSET and
+// INT64_MAX for the sec_key bounds to ignore that axis.
+NANOTS_API nanots_ec_t nanots_reader_read(
+    nanots_reader_t reader,
+    const char* stream_tag,
+    int64_t start_timestamp,
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key,
+    nanots_read_callback_t callback,
+    void* user_data
+);
 
 NANOTS_API nanots_ec_t nanots_reader_query_contiguous_segments(
     nanots_reader_t reader,
     const char* stream_tag,
     int64_t start_timestamp,
+    int64_t start_secondary_key,
     int64_t end_timestamp,
+    int64_t end_secondary_key,
     nanots_contiguous_segment_t** segments,
-    size_t* count);
+    size_t* count
+);
 
 NANOTS_API void nanots_free_contiguous_segments(nanots_contiguous_segment_t* segments);
 
-NANOTS_API nanots_ec_t nanots_reader_query_stream_tags_start(nanots_reader_t reader,
-                                                  int64_t start_timestamp,
-                                                  int64_t end_timestamp);
+NANOTS_API nanots_ec_t nanots_reader_query_stream_tags_start(
+    nanots_reader_t reader,
+    int64_t start_timestamp,
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key
+);
 
 NANOTS_API const char* nanots_reader_query_stream_tags_next(nanots_reader_t reader);
 
 // iterator
-NANOTS_API nanots_iterator_t nanots_iterator_create(const char* file_name,
-                                         const char* stream_tag);
+NANOTS_API nanots_iterator_t nanots_iterator_create(
+    const char* file_name,
+    const char* stream_tag
+);
+
 NANOTS_API void nanots_iterator_destroy(nanots_iterator_t iterator);
 
 NANOTS_API int nanots_iterator_valid(nanots_iterator_t iterator);
 
 NANOTS_API nanots_ec_t nanots_iterator_get_current_frame(
     nanots_iterator_t iterator,
-    nanots_frame_info_t* frame_info);
+    nanots_frame_info_t* frame_info
+);
 
 NANOTS_API nanots_ec_t nanots_iterator_next(nanots_iterator_t iterator);
 
@@ -1081,9 +1177,11 @@ NANOTS_API nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator);
 // Find the first frame whose composite (timestamp, secondary_key) is >= the
 // requested composite. Pass NANOTS_SEC_KEY_UNSET for `secondary_key` to land
 // on the first frame at the requested timestamp.
-NANOTS_API nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
-                                            int64_t timestamp,
-                                            int64_t secondary_key);
+NANOTS_API nanots_ec_t nanots_iterator_find(
+    nanots_iterator_t iterator,
+    int64_t timestamp,
+    int64_t secondary_key
+);
 
 NANOTS_API nanots_ec_t nanots_iterator_reset(nanots_iterator_t iterator);
 

--- a/bindings/nanots-go/callback.go
+++ b/bindings/nanots-go/callback.go
@@ -6,8 +6,9 @@ package nanots
 
 typedef void (*nanots_read_callback_t)(const uint8_t* data,
                                        size_t size,
-                                       uint8_t flags,
+                                       uint32_t flags,
                                        int64_t timestamp,
+                                       int64_t secondary_key,
                                        int64_t block_sequence,
                                        const char* metadata,
                                        void* user_data);
@@ -18,8 +19,8 @@ import (
 )
 
 //export goReadCallback
-func goReadCallback(data *C.uint8_t, size C.size_t, flags C.uint8_t,
-	timestamp C.int64_t, blockSequence C.int64_t,
+func goReadCallback(data *C.uint8_t, size C.size_t, flags C.uint32_t,
+	timestamp C.int64_t, secondaryKey C.int64_t, blockSequence C.int64_t,
 	metadata *C.char, userData unsafe.Pointer) {
 
 	// Get the callback ID from user_data
@@ -42,8 +43,9 @@ func goReadCallback(data *C.uint8_t, size C.size_t, flags C.uint8_t,
 	frame := Frame{
 		Data:          goData,
 		Timestamp:     int64(timestamp),
+		SecondaryKey:  int64(secondaryKey),
 		BlockSequence: int64(blockSequence),
-		Flags:         uint8(flags),
+		Flags:         uint32(flags),
 		Metadata:      C.GoString(metadata),
 	}
 

--- a/bindings/nanots-go/nanots.go
+++ b/bindings/nanots-go/nanots.go
@@ -15,8 +15,9 @@ package nanots
 #include "../../amalgamated_src/nanots.h"
 
 // Callback bridge for Go
-extern void goReadCallback(const uint8_t* data, size_t size, uint8_t flags,
-                          int64_t timestamp, int64_t block_sequence,
+extern void goReadCallback(const uint8_t* data, size_t size, uint32_t flags,
+                          int64_t timestamp, int64_t secondary_key,
+                          int64_t block_sequence,
                           const char* metadata, void* user_data);
 */
 import "C"
@@ -32,21 +33,29 @@ import (
 type ErrorCode int
 
 const (
-	ErrOK                      ErrorCode = C.NANOTS_EC_OK
-	ErrCantOpen                ErrorCode = C.NANOTS_EC_CANT_OPEN
-	ErrSchema                  ErrorCode = C.NANOTS_EC_SCHEMA
-	ErrNoFreeBlocks            ErrorCode = C.NANOTS_EC_NO_FREE_BLOCKS
-	ErrInvalidBlockSize        ErrorCode = C.NANOTS_EC_INVALID_BLOCK_SIZE
-	ErrDuplicateStreamTag      ErrorCode = C.NANOTS_EC_DUPLICATE_STREAM_TAG
-	ErrUnableToCreateSegment   ErrorCode = C.NANOTS_EC_UNABLE_TO_CREATE_SEGMENT
+	ErrOK                         ErrorCode = C.NANOTS_EC_OK
+	ErrCantOpen                   ErrorCode = C.NANOTS_EC_CANT_OPEN
+	ErrSchema                     ErrorCode = C.NANOTS_EC_SCHEMA
+	ErrNoFreeBlocks               ErrorCode = C.NANOTS_EC_NO_FREE_BLOCKS
+	ErrInvalidBlockSize           ErrorCode = C.NANOTS_EC_INVALID_BLOCK_SIZE
+	ErrDuplicateStreamTag         ErrorCode = C.NANOTS_EC_DUPLICATE_STREAM_TAG
+	ErrUnableToCreateSegment      ErrorCode = C.NANOTS_EC_UNABLE_TO_CREATE_SEGMENT
 	ErrUnableToCreateSegmentBlock ErrorCode = C.NANOTS_EC_UNABLE_TO_CREATE_SEGMENT_BLOCK
-	ErrNonMonotonicTimestamp   ErrorCode = C.NANOTS_EC_NON_MONOTONIC_TIMESTAMP
-	ErrRowSizeTooBig           ErrorCode = C.NANOTS_EC_ROW_SIZE_TOO_BIG
-	ErrUnableToAllocateFile    ErrorCode = C.NANOTS_EC_UNABLE_TO_ALLOCATE_FILE
-	ErrInvalidArgument         ErrorCode = C.NANOTS_EC_INVALID_ARGUMENT
-	ErrUnknown                 ErrorCode = C.NANOTS_EC_UNKNOWN
-	ErrNotFound                ErrorCode = C.NANOTS_EC_NOT_FOUND
+	ErrNonMonotonicTimestamp      ErrorCode = C.NANOTS_EC_NON_MONOTONIC_TIMESTAMP
+	ErrRowSizeTooBig              ErrorCode = C.NANOTS_EC_ROW_SIZE_TOO_BIG
+	ErrUnableToAllocateFile       ErrorCode = C.NANOTS_EC_UNABLE_TO_ALLOCATE_FILE
+	ErrInvalidArgument            ErrorCode = C.NANOTS_EC_INVALID_ARGUMENT
+	ErrUnknown                    ErrorCode = C.NANOTS_EC_UNKNOWN
+	ErrNotFound                   ErrorCode = C.NANOTS_EC_NOT_FOUND
+	ErrBadMagic                   ErrorCode = C.NANOTS_EC_BAD_MAGIC
+	ErrBadVersion                 ErrorCode = C.NANOTS_EC_BAD_VERSION
+	ErrSecondaryKeyMismatch       ErrorCode = C.NANOTS_EC_SECONDARY_KEY_MISMATCH
+	ErrNonMonotonicSecondaryKey   ErrorCode = C.NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY
 )
+
+// SecKeyUnset is the sentinel for "this frame has no secondary key". Mirrors
+// the C-level NANOTS_SEC_KEY_UNSET (INT64_MIN).
+const SecKeyUnset int64 = -1 << 63
 
 // Error represents a nanots error with an error code
 type Error struct {
@@ -89,6 +98,14 @@ func newError(code ErrorCode) error {
 		msg = "invalid argument"
 	case ErrNotFound:
 		msg = "not found"
+	case ErrBadMagic:
+		msg = "not a nanots v2 file (bad magic)"
+	case ErrBadVersion:
+		msg = "unsupported nanots format version"
+	case ErrSecondaryKeyMismatch:
+		msg = "stream secondary-key mode mismatch"
+	case ErrNonMonotonicSecondaryKey:
+		msg = "secondary key must be monotonic"
 	default:
 		msg = "unknown error"
 	}
@@ -196,8 +213,20 @@ func (wc *WriteContext) Close() error {
 	return nil
 }
 
-// Write writes data to the database with the specified timestamp and flags
-func (w *Writer) Write(ctx *WriteContext, data []byte, timestamp int64, flags uint8) error {
+// Write writes data to an *unkeyed* stream. Equivalent to
+// WriteWithSecondaryKey with secondaryKey = SecKeyUnset. For keyed streams
+// use WriteWithSecondaryKey instead.
+func (w *Writer) Write(ctx *WriteContext, data []byte, flags uint32,
+	timestamp int64) error {
+	return w.WriteWithSecondaryKey(ctx, data, flags, timestamp, SecKeyUnset)
+}
+
+// WriteWithSecondaryKey writes data to the database, including an explicit
+// secondary key. Pass any int64 except math.MinInt64 (= SecKeyUnset) to
+// write into a keyed stream. The first write to a stream tag fixes the
+// stream as keyed or unkeyed; mixing returns ErrSecondaryKeyMismatch.
+func (w *Writer) WriteWithSecondaryKey(ctx *WriteContext, data []byte,
+	flags uint32, timestamp int64, secondaryKey int64) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -218,8 +247,9 @@ func (w *Writer) Write(ctx *WriteContext, data []byte, timestamp int64, flags ui
 		ctx.handle,
 		dataPtr,
 		C.size_t(len(data)),
+		C.uint32_t(flags),
 		C.int64_t(timestamp),
-		C.uint8_t(flags),
+		C.int64_t(secondaryKey),
 	)
 	return newError(ErrorCode(ec))
 }
@@ -277,8 +307,9 @@ func (r *Reader) Close() error {
 type Frame struct {
 	Data          []byte
 	Timestamp     int64
+	SecondaryKey  int64
 	BlockSequence int64
-	Flags         uint8
+	Flags         uint32
 	Metadata      string
 }
 
@@ -458,8 +489,9 @@ func (it *Iterator) Valid() bool {
 type FrameInfo struct {
 	Data          []byte
 	Timestamp     int64
+	SecondaryKey  int64
 	BlockSequence int64
-	Flags         uint8
+	Flags         uint32
 }
 
 // Current returns the current frame information
@@ -483,8 +515,9 @@ func (it *Iterator) Current() (FrameInfo, error) {
 	return FrameInfo{
 		Data:          data,
 		Timestamp:     int64(cFrame.timestamp),
+		SecondaryKey:  int64(cFrame.secondary_key),
 		BlockSequence: int64(cFrame.block_sequence),
-		Flags:         uint8(cFrame.flags),
+		Flags:         uint32(cFrame.flags),
 	}, nil
 }
 
@@ -525,6 +558,32 @@ func (it *Iterator) Find(timestamp int64) error {
 
 	ec := C.nanots_iterator_find(it.handle, C.int64_t(timestamp))
 	return newError(ErrorCode(ec))
+}
+
+// FindBySecondaryKey seeks to the first frame whose secondary key is >=
+// the specified value. Only valid on streams that store a secondary key.
+func (it *Iterator) FindBySecondaryKey(secondaryKey int64) error {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+
+	if it.handle == nil {
+		return errors.New("iterator is closed")
+	}
+
+	ec := C.nanots_iterator_find_by_secondary_key(it.handle, C.int64_t(secondaryKey))
+	return newError(ErrorCode(ec))
+}
+
+// HasSecondaryKey reports whether this stream stores a secondary key on
+// every frame.
+func (it *Iterator) HasSecondaryKey() bool {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+
+	if it.handle == nil {
+		return false
+	}
+	return C.nanots_iterator_has_secondary_key(it.handle) != 0
 }
 
 // Reset moves the iterator to the first frame

--- a/bindings/nanots-go/nanots.go
+++ b/bindings/nanots-go/nanots.go
@@ -51,9 +51,13 @@ const (
 	ErrBadVersion                 ErrorCode = C.NANOTS_EC_BAD_VERSION
 )
 
-// SecKeyUnset is the sentinel for "this frame has no secondary key". Mirrors
-// the C-level NANOTS_SEC_KEY_UNSET (INT64_MIN).
+// SecKeyUnset is the sentinel for "no secondary key" (mirrors the C-level
+// NANOTS_SEC_KEY_UNSET = INT64_MIN). Smallest possible secondary key.
 const SecKeyUnset int64 = -1 << 63
+
+// SecKeyMax is the largest possible secondary key. Default upper bound
+// for range queries that don't want to constrain on sec_key.
+const SecKeyMax int64 = (1 << 63) - 1
 
 // Error represents a nanots error with an error code
 type Error struct {
@@ -251,8 +255,21 @@ func (w *Writer) WriteWithSecondaryKey(ctx *WriteContext, data []byte,
 	return newError(ErrorCode(ec))
 }
 
-// FreeBlocks frees blocks in the specified time range for the given stream tag
+// FreeBlocks frees blocks in the specified time range (no sec_key
+// tiebreaker). Equivalent to FreeBlocksWithSecondaryKeys with
+// SecKeyUnset / SecKeyMax for the sec_key bounds.
 func FreeBlocks(fileName, streamTag string, startTimestamp, endTimestamp int64) error {
+	return FreeBlocksWithSecondaryKeys(
+		fileName, streamTag,
+		startTimestamp, SecKeyUnset,
+		endTimestamp, SecKeyMax,
+	)
+}
+
+// FreeBlocksWithSecondaryKeys frees blocks fully contained in the composite
+// window [(startTimestamp, startSecondaryKey), (endTimestamp, endSecondaryKey)].
+func FreeBlocksWithSecondaryKeys(fileName, streamTag string,
+	startTimestamp, startSecondaryKey, endTimestamp, endSecondaryKey int64) error {
 	cFileName := C.CString(fileName)
 	defer C.free(unsafe.Pointer(cFileName))
 	cStreamTag := C.CString(streamTag)
@@ -262,7 +279,9 @@ func FreeBlocks(fileName, streamTag string, startTimestamp, endTimestamp int64) 
 		cFileName,
 		cStreamTag,
 		C.int64_t(startTimestamp),
+		C.int64_t(startSecondaryKey),
 		C.int64_t(endTimestamp),
+		C.int64_t(endSecondaryKey),
 	)
 	return newError(ErrorCode(ec))
 }
@@ -319,8 +338,22 @@ var (
 	callbackID    uintptr
 )
 
-// Read reads data from the specified stream in the given time range
+// Read reads data from the specified stream in the given time range (no
+// sec_key tiebreaker). Equivalent to ReadWithSecondaryKeys with
+// SecKeyUnset / SecKeyMax for the sec_key bounds.
 func (r *Reader) Read(streamTag string, startTimestamp, endTimestamp int64, callback ReadCallback) error {
+	return r.ReadWithSecondaryKeys(streamTag,
+		startTimestamp, SecKeyUnset,
+		endTimestamp, SecKeyMax,
+		callback)
+}
+
+// ReadWithSecondaryKeys reads frames whose composite (timestamp,
+// secondary_key) lies in [(startTimestamp, startSecondaryKey),
+// (endTimestamp, endSecondaryKey)].
+func (r *Reader) ReadWithSecondaryKeys(streamTag string,
+	startTimestamp, startSecondaryKey, endTimestamp, endSecondaryKey int64,
+	callback ReadCallback) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -348,15 +381,28 @@ func (r *Reader) Read(streamTag string, startTimestamp, endTimestamp int64, call
 		r.handle,
 		cStreamTag,
 		C.int64_t(startTimestamp),
+		C.int64_t(startSecondaryKey),
 		C.int64_t(endTimestamp),
+		C.int64_t(endSecondaryKey),
 		C.nanots_read_callback_t(C.goReadCallback),
 		unsafe.Pointer(id),
 	)
 	return newError(ErrorCode(ec))
 }
 
-// QueryStreamTags returns all stream tags in the specified time range
+// QueryStreamTags returns all stream tags in the specified time range (no
+// sec_key tiebreaker).
 func (r *Reader) QueryStreamTags(startTimestamp, endTimestamp int64) ([]string, error) {
+	return r.QueryStreamTagsWithSecondaryKeys(
+		startTimestamp, SecKeyUnset,
+		endTimestamp, SecKeyMax)
+}
+
+// QueryStreamTagsWithSecondaryKeys returns all stream tags whose blocks
+// overlap the composite window.
+func (r *Reader) QueryStreamTagsWithSecondaryKeys(
+	startTimestamp, startSecondaryKey, endTimestamp, endSecondaryKey int64,
+) ([]string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -367,7 +413,9 @@ func (r *Reader) QueryStreamTags(startTimestamp, endTimestamp int64) ([]string, 
 	ec := C.nanots_reader_query_stream_tags_start(
 		r.handle,
 		C.int64_t(startTimestamp),
+		C.int64_t(startSecondaryKey),
 		C.int64_t(endTimestamp),
+		C.int64_t(endSecondaryKey),
 	)
 	if err := newError(ErrorCode(ec)); err != nil {
 		return nil, err
@@ -387,13 +435,26 @@ func (r *Reader) QueryStreamTags(startTimestamp, endTimestamp int64) ([]string, 
 
 // ContiguousSegment represents a contiguous segment of data
 type ContiguousSegment struct {
-	SegmentID      int64
-	StartTimestamp int64
-	EndTimestamp   int64
+	SegmentID         int64
+	StartTimestamp    int64
+	StartSecondaryKey int64
+	EndTimestamp      int64
+	EndSecondaryKey   int64
 }
 
-// QueryContiguousSegments returns all contiguous segments for the specified stream in the given time range
+// QueryContiguousSegments returns all contiguous segments for the specified
+// stream in the given time range (no sec_key tiebreaker).
 func (r *Reader) QueryContiguousSegments(streamTag string, startTimestamp, endTimestamp int64) ([]ContiguousSegment, error) {
+	return r.QueryContiguousSegmentsWithSecondaryKeys(streamTag,
+		startTimestamp, SecKeyUnset,
+		endTimestamp, SecKeyMax)
+}
+
+// QueryContiguousSegmentsWithSecondaryKeys returns contiguous block runs
+// within the composite window.
+func (r *Reader) QueryContiguousSegmentsWithSecondaryKeys(streamTag string,
+	startTimestamp, startSecondaryKey, endTimestamp, endSecondaryKey int64,
+) ([]ContiguousSegment, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -411,7 +472,9 @@ func (r *Reader) QueryContiguousSegments(streamTag string, startTimestamp, endTi
 		r.handle,
 		cStreamTag,
 		C.int64_t(startTimestamp),
+		C.int64_t(startSecondaryKey),
 		C.int64_t(endTimestamp),
+		C.int64_t(endSecondaryKey),
 		&segments,
 		&count,
 	)
@@ -427,9 +490,11 @@ func (r *Reader) QueryContiguousSegments(streamTag string, startTimestamp, endTi
 	segmentSlice := unsafe.Slice(segments, int(count))
 	for i, seg := range segmentSlice {
 		result[i] = ContiguousSegment{
-			SegmentID:      int64(seg.segment_id),
-			StartTimestamp: int64(seg.start_timestamp),
-			EndTimestamp:   int64(seg.end_timestamp),
+			SegmentID:         int64(seg.segment_id),
+			StartTimestamp:    int64(seg.start_timestamp),
+			StartSecondaryKey: int64(seg.start_secondary_key),
+			EndTimestamp:      int64(seg.end_timestamp),
+			EndSecondaryKey:   int64(seg.end_secondary_key),
 		}
 	}
 

--- a/bindings/nanots-go/nanots.go
+++ b/bindings/nanots-go/nanots.go
@@ -49,8 +49,6 @@ const (
 	ErrNotFound                   ErrorCode = C.NANOTS_EC_NOT_FOUND
 	ErrBadMagic                   ErrorCode = C.NANOTS_EC_BAD_MAGIC
 	ErrBadVersion                 ErrorCode = C.NANOTS_EC_BAD_VERSION
-	ErrSecondaryKeyMismatch       ErrorCode = C.NANOTS_EC_SECONDARY_KEY_MISMATCH
-	ErrNonMonotonicSecondaryKey   ErrorCode = C.NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY
 )
 
 // SecKeyUnset is the sentinel for "this frame has no secondary key". Mirrors
@@ -102,10 +100,6 @@ func newError(code ErrorCode) error {
 		msg = "not a nanots v2 file (bad magic)"
 	case ErrBadVersion:
 		msg = "unsupported nanots format version"
-	case ErrSecondaryKeyMismatch:
-		msg = "stream secondary-key mode mismatch"
-	case ErrNonMonotonicSecondaryKey:
-		msg = "secondary key must be monotonic"
 	default:
 		msg = "unknown error"
 	}
@@ -213,18 +207,21 @@ func (wc *WriteContext) Close() error {
 	return nil
 }
 
-// Write writes data to an *unkeyed* stream. Equivalent to
-// WriteWithSecondaryKey with secondaryKey = SecKeyUnset. For keyed streams
-// use WriteWithSecondaryKey instead.
+// Write writes a frame with no secondary key. Equivalent to
+// WriteWithSecondaryKey with secondaryKey = SecKeyUnset. Composite ordering
+// degenerates to "timestamp strictly increasing" for streams that always
+// call Write.
 func (w *Writer) Write(ctx *WriteContext, data []byte, flags uint32,
 	timestamp int64) error {
 	return w.WriteWithSecondaryKey(ctx, data, flags, timestamp, SecKeyUnset)
 }
 
-// WriteWithSecondaryKey writes data to the database, including an explicit
-// secondary key. Pass any int64 except math.MinInt64 (= SecKeyUnset) to
-// write into a keyed stream. The first write to a stream tag fixes the
-// stream as keyed or unkeyed; mixing returns ErrSecondaryKeyMismatch.
+// WriteWithSecondaryKey writes a frame with an explicit secondary key.
+//
+// Frames are ordered by the composite (timestamp, secondaryKey), which must
+// strictly increase across writes. Pass any int64 except math.MinInt64 (=
+// SecKeyUnset) to disambiguate frames at the same timestamp. Violating the
+// composite ordering returns ErrNonMonotonicTimestamp.
 func (w *Writer) WriteWithSecondaryKey(ctx *WriteContext, data []byte,
 	flags uint32, timestamp int64, secondaryKey int64) error {
 	w.mu.Lock()
@@ -547,8 +544,10 @@ func (it *Iterator) Prev() error {
 	return newError(ErrorCode(ec))
 }
 
-// Find seeks to the first frame with timestamp >= the specified timestamp
-func (it *Iterator) Find(timestamp int64) error {
+// Find seeks to the first frame whose composite (timestamp, secondaryKey)
+// is >= the requested composite. Pass SecKeyUnset for secondaryKey to land
+// on the first frame at the requested timestamp regardless of sec_key.
+func (it *Iterator) Find(timestamp int64, secondaryKey int64) error {
 	it.mu.Lock()
 	defer it.mu.Unlock()
 
@@ -556,34 +555,9 @@ func (it *Iterator) Find(timestamp int64) error {
 		return errors.New("iterator is closed")
 	}
 
-	ec := C.nanots_iterator_find(it.handle, C.int64_t(timestamp))
+	ec := C.nanots_iterator_find(it.handle, C.int64_t(timestamp),
+		C.int64_t(secondaryKey))
 	return newError(ErrorCode(ec))
-}
-
-// FindBySecondaryKey seeks to the first frame whose secondary key is >=
-// the specified value. Only valid on streams that store a secondary key.
-func (it *Iterator) FindBySecondaryKey(secondaryKey int64) error {
-	it.mu.Lock()
-	defer it.mu.Unlock()
-
-	if it.handle == nil {
-		return errors.New("iterator is closed")
-	}
-
-	ec := C.nanots_iterator_find_by_secondary_key(it.handle, C.int64_t(secondaryKey))
-	return newError(ErrorCode(ec))
-}
-
-// HasSecondaryKey reports whether this stream stores a secondary key on
-// every frame.
-func (it *Iterator) HasSecondaryKey() bool {
-	it.mu.Lock()
-	defer it.mu.Unlock()
-
-	if it.handle == nil {
-		return false
-	}
-	return C.nanots_iterator_has_secondary_key(it.handle) != 0
 }
 
 // Reset moves the iterator to the first frame

--- a/bindings/nanots-go/nanots_test.go
+++ b/bindings/nanots-go/nanots_test.go
@@ -31,12 +31,12 @@ func TestBasicWriteReadCycle(t *testing.T) {
 		}
 		defer ctx.Close()
 
-		err = writer.Write(ctx, []byte("hello world"), 1000, 0)
+		err = writer.Write(ctx, []byte("hello world"), 0, 1000)
 		if err != nil {
 			t.Fatalf("Failed to write first frame: %v", err)
 		}
 
-		err = writer.Write(ctx, []byte("goodbye world"), 2000, 1)
+		err = writer.Write(ctx, []byte("goodbye world"), 1, 2000)
 		if err != nil {
 			t.Fatalf("Failed to write second frame: %v", err)
 		}
@@ -52,7 +52,7 @@ func TestBasicWriteReadCycle(t *testing.T) {
 
 		type record struct {
 			data      []byte
-			flags     uint8
+			flags     uint32
 			timestamp int64
 		}
 		var records []record
@@ -118,7 +118,7 @@ func TestIteratorInterface(t *testing.T) {
 
 		for i := 0; i < 5; i++ {
 			data := fmt.Sprintf("item_%d", i)
-			err = writer.Write(ctx, []byte(data), int64(i*1000), 0)
+			err = writer.Write(ctx, []byte(data), 0, int64(i*1000))
 			if err != nil {
 				t.Fatalf("Failed to write frame %d: %v", i, err)
 			}
@@ -194,7 +194,7 @@ func TestFindFunctionality(t *testing.T) {
 		timestamps := []int64{1000, 2000, 3000, 5000, 8000}
 		for i, timestamp := range timestamps {
 			data := fmt.Sprintf("data_%d", i)
-			err = writer.Write(ctx, []byte(data), timestamp, 0)
+			err = writer.Write(ctx, []byte(data), 0, timestamp)
 			if err != nil {
 				t.Fatalf("Failed to write frame %d: %v", i, err)
 			}
@@ -291,7 +291,7 @@ func TestContiguousSegments(t *testing.T) {
 		}
 		defer ctx.Close()
 
-		err = writer.Write(ctx, []byte("test data"), 1000, 0)
+		err = writer.Write(ctx, []byte("test data"), 0, 1000)
 		if err != nil {
 			t.Fatalf("Failed to write data: %v", err)
 		}
@@ -372,22 +372,22 @@ func TestMultipleStreams(t *testing.T) {
 		}
 		defer ctx2.Close()
 
-		err = writer.Write(ctx1, []byte("stream1_data1"), 1000, 0)
+		err = writer.Write(ctx1, []byte("stream1_data1"), 0, 1000)
 		if err != nil {
 			t.Fatalf("Failed to write to stream1: %v", err)
 		}
 
-		err = writer.Write(ctx2, []byte("stream2_data1"), 1500, 0)
+		err = writer.Write(ctx2, []byte("stream2_data1"), 0, 1500)
 		if err != nil {
 			t.Fatalf("Failed to write to stream2: %v", err)
 		}
 
-		err = writer.Write(ctx1, []byte("stream1_data2"), 2000, 0)
+		err = writer.Write(ctx1, []byte("stream1_data2"), 0, 2000)
 		if err != nil {
 			t.Fatalf("Failed to write to stream1: %v", err)
 		}
 
-		err = writer.Write(ctx2, []byte("stream2_data2"), 2500, 0)
+		err = writer.Write(ctx2, []byte("stream2_data2"), 0, 2500)
 		if err != nil {
 			t.Fatalf("Failed to write to stream2: %v", err)
 		}
@@ -489,7 +489,7 @@ func TestQueryStreamTags(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create context for %s: %v", streamTag, err)
 			}
-			err = writer.Write(ctx, []byte("data"), 1000, 0)
+			err = writer.Write(ctx, []byte("data"), 0, 1000)
 			if err != nil {
 				t.Fatalf("Failed to write to %s: %v", streamTag, err)
 			}

--- a/bindings/nanots-go/nanots_test.go
+++ b/bindings/nanots-go/nanots_test.go
@@ -210,7 +210,7 @@ func TestFindFunctionality(t *testing.T) {
 		defer iter.Close()
 
 		// Find timestamp that exists
-		err = iter.Find(3000)
+		err = iter.Find(3000, SecKeyUnset)
 		if err != nil {
 			t.Fatalf("Failed to find timestamp 3000: %v", err)
 		}
@@ -229,7 +229,7 @@ func TestFindFunctionality(t *testing.T) {
 		}
 
 		// Find timestamp between existing ones (should find next)
-		err = iter.Find(4000)
+		err = iter.Find(4000, SecKeyUnset)
 		if err != nil {
 			t.Fatalf("Failed to find timestamp 4000: %v", err)
 		}
@@ -248,7 +248,7 @@ func TestFindFunctionality(t *testing.T) {
 		}
 
 		// Find timestamp before any data
-		err = iter.Find(500)
+		err = iter.Find(500, SecKeyUnset)
 		if err != nil {
 			t.Fatalf("Failed to find timestamp 500: %v", err)
 		}

--- a/bindings/nanots-rs/src/lib.rs
+++ b/bindings/nanots-rs/src/lib.rs
@@ -57,8 +57,6 @@ pub enum ErrorCode {
     NotFound = 13,
     BadMagic = 14,
     BadVersion = 15,
-    SecondaryKeyMismatch = 16,
-    NonMonotonicSecondaryKey = 17,
 }
 
 impl ErrorCode {
@@ -79,8 +77,6 @@ impl ErrorCode {
             13 => ErrorCode::NotFound,
             14 => ErrorCode::BadMagic,
             15 => ErrorCode::BadVersion,
-            16 => ErrorCode::SecondaryKeyMismatch,
-            17 => ErrorCode::NonMonotonicSecondaryKey,
             _ => ErrorCode::Unknown,
         }
     }
@@ -105,8 +101,6 @@ impl std::fmt::Display for ErrorCode {
             ErrorCode::NotFound => "Not found",
             ErrorCode::BadMagic => "Not a nanots v2 file (bad magic)",
             ErrorCode::BadVersion => "Unsupported nanots format version",
-            ErrorCode::SecondaryKeyMismatch => "Stream secondary-key mode mismatch",
-            ErrorCode::NonMonotonicSecondaryKey => "Secondary key must be monotonic",
         };
         write!(f, "{}", msg)
     }
@@ -238,12 +232,9 @@ extern "C" {
     ) -> u32;
     fn nanots_iterator_next(iterator: IteratorPtr) -> u32;
     fn nanots_iterator_prev(iterator: IteratorPtr) -> u32;
-    fn nanots_iterator_find(iterator: IteratorPtr, timestamp: i64) -> u32;
-    fn nanots_iterator_find_by_secondary_key(
-        iterator: IteratorPtr,
-        secondary_key: i64,
-    ) -> u32;
-    fn nanots_iterator_has_secondary_key(iterator: IteratorPtr) -> c_int;
+    fn nanots_iterator_find(iterator: IteratorPtr,
+                            timestamp: i64,
+                            secondary_key: i64) -> u32;
     fn nanots_iterator_reset(iterator: IteratorPtr) -> u32;
     fn nanots_iterator_current_block_sequence(iterator: IteratorPtr) -> i64;
     fn nanots_iterator_current_metadata(iterator: IteratorPtr) -> *const c_char;
@@ -284,12 +275,11 @@ impl Writer {
         }
     }
 
-    /// Write data to an *unkeyed* stream.
+    /// Write a frame with no secondary key.
     ///
-    /// The first write to a stream tag fixes the stream as either keyed or
-    /// unkeyed; this method always passes `SEC_KEY_UNSET`, so use it only on
-    /// streams that have no secondary key. For keyed streams use
-    /// [`write_with_secondary_key`](Self::write_with_secondary_key).
+    /// Equivalent to `write_with_secondary_key` with `secondary_key =
+    /// SEC_KEY_UNSET`. Composite ordering degenerates to "timestamp strictly
+    /// increasing" for streams that always call `write`.
     pub fn write(
         &self,
         context: &WriteContext,
@@ -300,12 +290,13 @@ impl Writer {
         self.write_with_secondary_key(context, data, flags, timestamp, SEC_KEY_UNSET)
     }
 
-    /// Write data with an explicit secondary key.
+    /// Write a frame with an explicit secondary key.
     ///
-    /// Pass any `i64` *except* `i64::MIN` (= [`SEC_KEY_UNSET`]) to write into
-    /// a keyed stream. Mixing keyed and unkeyed writes on the same stream
-    /// returns [`ErrorCode::SecondaryKeyMismatch`]; non-monotonic keys
-    /// return [`ErrorCode::NonMonotonicSecondaryKey`].
+    /// Frames are ordered by the composite `(timestamp, secondary_key)`,
+    /// which must strictly increase across writes. Pass any `i64` *except*
+    /// `i64::MIN` (= [`SEC_KEY_UNSET`]) as a real key — use it to
+    /// disambiguate frames at the same timestamp. Violating the composite
+    /// ordering returns [`ErrorCode::NonMonotonicTimestamp`].
     pub fn write_with_secondary_key(
         &self,
         context: &WriteContext,
@@ -692,25 +683,16 @@ impl Iterator {
         }
     }
 
-    /// Find the first frame at or after the given timestamp
-    pub fn find(&mut self, timestamp: i64) -> Result<bool> {
-        let result = unsafe { nanots_iterator_find(self.ptr, timestamp) };
+    /// Find the first frame whose composite `(timestamp, secondary_key)`
+    /// is `>=` the requested composite.
+    ///
+    /// Pass `secondary_key = SEC_KEY_UNSET` to land on the first frame at
+    /// the requested timestamp regardless of sec_key (since `SEC_KEY_UNSET`
+    /// is the smallest possible sec_key in lex order).
+    pub fn find(&mut self, timestamp: i64, secondary_key: i64) -> Result<bool> {
+        let result = unsafe { nanots_iterator_find(self.ptr, timestamp, secondary_key) };
         let error_code = ErrorCode::from_c(result);
         Ok(error_code == ErrorCode::Ok)
-    }
-
-    /// Find the first frame at or after the given secondary key. Only valid
-    /// on streams whose [`has_secondary_key`](Self::has_secondary_key) is true.
-    pub fn find_by_secondary_key(&mut self, secondary_key: i64) -> Result<bool> {
-        let result =
-            unsafe { nanots_iterator_find_by_secondary_key(self.ptr, secondary_key) };
-        let error_code = ErrorCode::from_c(result);
-        Ok(error_code == ErrorCode::Ok)
-    }
-
-    /// True if this stream stores a secondary key on every frame.
-    pub fn has_secondary_key(&self) -> bool {
-        unsafe { nanots_iterator_has_secondary_key(self.ptr) != 0 }
     }
 
     /// Reset to the first frame

--- a/bindings/nanots-rs/src/lib.rs
+++ b/bindings/nanots-rs/src/lib.rs
@@ -33,9 +33,13 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
 use std::slice;
 
-/// Sentinel for "frame has no secondary key" (matches the C-level
-/// `NANOTS_SEC_KEY_UNSET = INT64_MIN`).
+/// Sentinel for "no secondary key" (matches the C-level
+/// `NANOTS_SEC_KEY_UNSET = INT64_MIN`). Smallest possible secondary key.
 pub const SEC_KEY_UNSET: i64 = i64::MIN;
+
+/// Largest possible secondary key. Default upper bound for range queries
+/// that don't want to constrain on sec_key.
+pub const SEC_KEY_MAX: i64 = i64::MAX;
 
 /// Error codes matching the C enum
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -117,7 +121,9 @@ pub type Result<T> = std::result::Result<T, ErrorCode>;
 pub struct ContiguousSegment {
     pub segment_id: i64,
     pub start_timestamp: i64,
+    pub start_secondary_key: i64,
     pub end_timestamp: i64,
+    pub end_secondary_key: i64,
 }
 
 #[repr(C)]
@@ -190,7 +196,9 @@ extern "C" {
         file_name: *const c_char,
         stream_tag: *const c_char,
         start_timestamp: i64,
+        start_secondary_key: i64,
         end_timestamp: i64,
+        end_secondary_key: i64,
     ) -> u32;
 
     fn nanots_reader_create(file_name: *const c_char) -> ReaderPtr;
@@ -199,7 +207,9 @@ extern "C" {
         reader: ReaderPtr,
         stream_tag: *const c_char,
         start_timestamp: i64,
+        start_secondary_key: i64,
         end_timestamp: i64,
+        end_secondary_key: i64,
         callback: ReadCallback,
         user_data: *mut c_void,
     ) -> u32;
@@ -207,7 +217,9 @@ extern "C" {
         reader: ReaderPtr,
         stream_tag: *const c_char,
         start_timestamp: i64,
+        start_secondary_key: i64,
         end_timestamp: i64,
+        end_secondary_key: i64,
         segments: *mut *mut ContiguousSegment,
         count: *mut usize,
     ) -> u32;
@@ -216,7 +228,9 @@ extern "C" {
     fn nanots_reader_query_stream_tags_start(
         reader: ReaderPtr,
         start_timestamp: i64,
+        start_secondary_key: i64,
         end_timestamp: i64,
+        end_secondary_key: i64,
     ) -> u32;
     fn nanots_reader_query_stream_tags_next(reader: ReaderPtr) -> *const c_char;
 
@@ -324,12 +338,32 @@ impl Writer {
         }
     }
 
-    /// Free blocks in a time range for a stream
+    /// Free blocks in a time range for a stream (no sec_key tiebreaker).
+    /// Equivalent to [`free_blocks_with_secondary_keys`](Self::free_blocks_with_secondary_keys)
+    /// with `start_secondary_key = SEC_KEY_UNSET` and
+    /// `end_secondary_key = SEC_KEY_MAX`.
     pub fn free_blocks(
         &self,
         stream_tag: &str,
         start_timestamp: i64,
         end_timestamp: i64,
+    ) -> Result<()> {
+        self.free_blocks_with_secondary_keys(
+            stream_tag,
+            start_timestamp, SEC_KEY_UNSET,
+            end_timestamp, SEC_KEY_MAX,
+        )
+    }
+
+    /// Free blocks fully contained in the composite window
+    /// `[(start_ts, start_sk), (end_ts, end_sk)]`.
+    pub fn free_blocks_with_secondary_keys(
+        &self,
+        stream_tag: &str,
+        start_timestamp: i64,
+        start_secondary_key: i64,
+        end_timestamp: i64,
+        end_secondary_key: i64,
     ) -> Result<()> {
         let c_stream_tag = CString::new(stream_tag).map_err(|_| ErrorCode::InvalidArgument)?;
         let result = unsafe {
@@ -337,7 +371,9 @@ impl Writer {
                 self.file_name.as_ptr(),
                 c_stream_tag.as_ptr(),
                 start_timestamp,
+                start_secondary_key,
                 end_timestamp,
+                end_secondary_key,
             )
         };
         let error_code = ErrorCode::from_c(result);
@@ -409,12 +445,31 @@ impl Drop for WriteContext {
     }
 }
 
-/// Free blocks in a time range for a stream (standalone function)
+/// Free blocks in a time range for a stream (standalone function, no
+/// sec_key tiebreaker). See also
+/// [`free_blocks_with_secondary_keys`](free_blocks_with_secondary_keys).
 pub fn free_blocks(
     file_name: &str,
     stream_tag: &str,
     start_timestamp: i64,
     end_timestamp: i64,
+) -> Result<()> {
+    free_blocks_with_secondary_keys(
+        file_name, stream_tag,
+        start_timestamp, SEC_KEY_UNSET,
+        end_timestamp, SEC_KEY_MAX,
+    )
+}
+
+/// Free blocks fully contained in the composite window
+/// `[(start_ts, start_sk), (end_ts, end_sk)]` (standalone function).
+pub fn free_blocks_with_secondary_keys(
+    file_name: &str,
+    stream_tag: &str,
+    start_timestamp: i64,
+    start_secondary_key: i64,
+    end_timestamp: i64,
+    end_secondary_key: i64,
 ) -> Result<()> {
     let c_file_name = CString::new(file_name).map_err(|_| ErrorCode::InvalidArgument)?;
     let c_stream_tag = CString::new(stream_tag).map_err(|_| ErrorCode::InvalidArgument)?;
@@ -423,7 +478,9 @@ pub fn free_blocks(
             c_file_name.as_ptr(),
             c_stream_tag.as_ptr(),
             start_timestamp,
+            start_secondary_key,
             end_timestamp,
+            end_secondary_key,
         )
     };
     let error_code = ErrorCode::from_c(result);
@@ -451,16 +508,41 @@ impl Reader {
         }
     }
 
-    /// Read data from a stream in a time range
-    ///
-    /// The callback receives: data slice, flags, timestamp, secondary_key,
-    /// block_sequence, and metadata. `secondary_key` will be `SEC_KEY_UNSET`
-    /// for streams that don't store one.
+    /// Read data from a stream in a time range (no sec_key tiebreaker).
+    /// Equivalent to [`read_with_secondary_keys`](Self::read_with_secondary_keys)
+    /// with `start_secondary_key = SEC_KEY_UNSET` and
+    /// `end_secondary_key = SEC_KEY_MAX`.
     pub fn read<F>(
         &self,
         stream_tag: &str,
         start_timestamp: i64,
         end_timestamp: i64,
+        callback: F,
+    ) -> Result<()>
+    where
+        F: FnMut(&[u8], u32, i64, i64, i64, &str),
+    {
+        self.read_with_secondary_keys(
+            stream_tag,
+            start_timestamp, SEC_KEY_UNSET,
+            end_timestamp, SEC_KEY_MAX,
+            callback,
+        )
+    }
+
+    /// Read frames whose composite `(timestamp, secondary_key)` lies in
+    /// `[(start_ts, start_sk), (end_ts, end_sk)]`.
+    ///
+    /// The callback receives: data slice, flags, timestamp, secondary_key,
+    /// block_sequence, and metadata. `secondary_key` will be `SEC_KEY_UNSET`
+    /// for frames whose writer didn't supply one.
+    pub fn read_with_secondary_keys<F>(
+        &self,
+        stream_tag: &str,
+        start_timestamp: i64,
+        start_secondary_key: i64,
+        end_timestamp: i64,
+        end_secondary_key: i64,
         mut callback: F,
     ) -> Result<()>
     where
@@ -501,7 +583,9 @@ impl Reader {
                 self.ptr,
                 c_stream_tag.as_ptr(),
                 start_timestamp,
+                start_secondary_key,
                 end_timestamp,
+                end_secondary_key,
                 c_callback,
                 user_data,
             )
@@ -515,12 +599,28 @@ impl Reader {
         }
     }
 
-    /// Query contiguous segments in a time range
+    /// Query contiguous segments in a time range (no sec_key tiebreaker).
     pub fn query_contiguous_segments(
         &self,
         stream_tag: &str,
         start_timestamp: i64,
         end_timestamp: i64,
+    ) -> Result<Vec<ContiguousSegment>> {
+        self.query_contiguous_segments_with_secondary_keys(
+            stream_tag,
+            start_timestamp, SEC_KEY_UNSET,
+            end_timestamp, SEC_KEY_MAX,
+        )
+    }
+
+    /// Query contiguous block runs within the composite window.
+    pub fn query_contiguous_segments_with_secondary_keys(
+        &self,
+        stream_tag: &str,
+        start_timestamp: i64,
+        start_secondary_key: i64,
+        end_timestamp: i64,
+        end_secondary_key: i64,
     ) -> Result<Vec<ContiguousSegment>> {
         let c_stream_tag = CString::new(stream_tag).map_err(|_| ErrorCode::InvalidArgument)?;
         let mut segments_ptr: *mut ContiguousSegment = ptr::null_mut();
@@ -531,7 +631,9 @@ impl Reader {
                 self.ptr,
                 c_stream_tag.as_ptr(),
                 start_timestamp,
+                start_secondary_key,
                 end_timestamp,
+                end_secondary_key,
                 &mut segments_ptr,
                 &mut count,
             )
@@ -551,14 +653,33 @@ impl Reader {
         Ok(segments)
     }
 
-    /// Query stream tags in a time range
+    /// Query stream tags in a time range (no sec_key tiebreaker).
     pub fn query_stream_tags(
         &self,
         start_timestamp: i64,
         end_timestamp: i64,
     ) -> Result<Vec<String>> {
-        let result =
-            unsafe { nanots_reader_query_stream_tags_start(self.ptr, start_timestamp, end_timestamp) };
+        self.query_stream_tags_with_secondary_keys(
+            start_timestamp, SEC_KEY_UNSET,
+            end_timestamp, SEC_KEY_MAX,
+        )
+    }
+
+    /// Distinct stream tags whose blocks overlap the composite window.
+    pub fn query_stream_tags_with_secondary_keys(
+        &self,
+        start_timestamp: i64,
+        start_secondary_key: i64,
+        end_timestamp: i64,
+        end_secondary_key: i64,
+    ) -> Result<Vec<String>> {
+        let result = unsafe {
+            nanots_reader_query_stream_tags_start(
+                self.ptr,
+                start_timestamp, start_secondary_key,
+                end_timestamp, end_secondary_key,
+            )
+        };
 
         let error_code = ErrorCode::from_c(result);
         if error_code != ErrorCode::Ok {

--- a/bindings/nanots-rs/src/lib.rs
+++ b/bindings/nanots-rs/src/lib.rs
@@ -13,14 +13,15 @@
 //! // Allocate a new database file
 //! Writer::allocate_file("data.nts", 1024 * 1024, 100)?;
 //!
-//! // Write some data
+//! // Write some data (unkeyed stream)
 //! let writer = Writer::new("data.nts", false)?;
 //! let context = writer.create_context("sensor_data", "temperature readings")?;
-//! writer.write(&context, b"hello world", 1234567890, 0)?;
+//! writer.write(&context, b"hello world", /*flags=*/0, 1234567890)?;
 //!
 //! // Read it back
 //! let reader = Reader::new("data.nts")?;
-//! reader.read("sensor_data", 0, i64::MAX, |data, flags, timestamp, block_seq, metadata| {
+//! reader.read("sensor_data", 0, i64::MAX,
+//!             |data, flags, timestamp, sec_key, block_seq, metadata| {
 //!     println!("Read {} bytes at timestamp {}, metadata: {}", data.len(), timestamp, metadata);
 //! })?;
 //! # Ok(())
@@ -31,6 +32,10 @@ use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr;
 use std::slice;
+
+/// Sentinel for "frame has no secondary key" (matches the C-level
+/// `NANOTS_SEC_KEY_UNSET = INT64_MIN`).
+pub const SEC_KEY_UNSET: i64 = i64::MIN;
 
 /// Error codes matching the C enum
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -50,6 +55,10 @@ pub enum ErrorCode {
     InvalidArgument = 11,
     Unknown = 12,
     NotFound = 13,
+    BadMagic = 14,
+    BadVersion = 15,
+    SecondaryKeyMismatch = 16,
+    NonMonotonicSecondaryKey = 17,
 }
 
 impl ErrorCode {
@@ -68,6 +77,10 @@ impl ErrorCode {
             10 => ErrorCode::UnableToAllocateFile,
             11 => ErrorCode::InvalidArgument,
             13 => ErrorCode::NotFound,
+            14 => ErrorCode::BadMagic,
+            15 => ErrorCode::BadVersion,
+            16 => ErrorCode::SecondaryKeyMismatch,
+            17 => ErrorCode::NonMonotonicSecondaryKey,
             _ => ErrorCode::Unknown,
         }
     }
@@ -90,6 +103,10 @@ impl std::fmt::Display for ErrorCode {
             ErrorCode::InvalidArgument => "Invalid argument",
             ErrorCode::Unknown => "Unknown error",
             ErrorCode::NotFound => "Not found",
+            ErrorCode::BadMagic => "Not a nanots v2 file (bad magic)",
+            ErrorCode::BadVersion => "Unsupported nanots format version",
+            ErrorCode::SecondaryKeyMismatch => "Stream secondary-key mode mismatch",
+            ErrorCode::NonMonotonicSecondaryKey => "Secondary key must be monotonic",
         };
         write!(f, "{}", msg)
     }
@@ -113,8 +130,9 @@ pub struct ContiguousSegment {
 struct FrameInfo {
     data: *const u8,
     size: usize,
-    flags: u8,
+    flags: u32,
     timestamp: i64,
+    secondary_key: i64,
     block_sequence: i64,
 }
 
@@ -133,8 +151,9 @@ type IteratorPtr = *mut IteratorHandle;
 type ReadCallback = extern "C" fn(
     data: *const u8,
     size: usize,
-    flags: u8,
+    flags: u32,
     timestamp: i64,
+    secondary_key: i64,
     block_sequence: i64,
     metadata: *const c_char,
     user_data: *mut c_void,
@@ -167,8 +186,9 @@ extern "C" {
         context: WriteContextPtr,
         data: *const u8,
         size: usize,
+        flags: u32,
         timestamp: i64,
-        flags: u8,
+        secondary_key: i64,
     ) -> u32;
 
     // Note: free_blocks takes file_name, not writer
@@ -219,6 +239,11 @@ extern "C" {
     fn nanots_iterator_next(iterator: IteratorPtr) -> u32;
     fn nanots_iterator_prev(iterator: IteratorPtr) -> u32;
     fn nanots_iterator_find(iterator: IteratorPtr, timestamp: i64) -> u32;
+    fn nanots_iterator_find_by_secondary_key(
+        iterator: IteratorPtr,
+        secondary_key: i64,
+    ) -> u32;
+    fn nanots_iterator_has_secondary_key(iterator: IteratorPtr) -> c_int;
     fn nanots_iterator_reset(iterator: IteratorPtr) -> u32;
     fn nanots_iterator_current_block_sequence(iterator: IteratorPtr) -> i64;
     fn nanots_iterator_current_metadata(iterator: IteratorPtr) -> *const c_char;
@@ -259,13 +284,35 @@ impl Writer {
         }
     }
 
-    /// Write data to the database
+    /// Write data to an *unkeyed* stream.
+    ///
+    /// The first write to a stream tag fixes the stream as either keyed or
+    /// unkeyed; this method always passes `SEC_KEY_UNSET`, so use it only on
+    /// streams that have no secondary key. For keyed streams use
+    /// [`write_with_secondary_key`](Self::write_with_secondary_key).
     pub fn write(
         &self,
         context: &WriteContext,
         data: &[u8],
+        flags: u32,
         timestamp: i64,
-        flags: u8,
+    ) -> Result<()> {
+        self.write_with_secondary_key(context, data, flags, timestamp, SEC_KEY_UNSET)
+    }
+
+    /// Write data with an explicit secondary key.
+    ///
+    /// Pass any `i64` *except* `i64::MIN` (= [`SEC_KEY_UNSET`]) to write into
+    /// a keyed stream. Mixing keyed and unkeyed writes on the same stream
+    /// returns [`ErrorCode::SecondaryKeyMismatch`]; non-monotonic keys
+    /// return [`ErrorCode::NonMonotonicSecondaryKey`].
+    pub fn write_with_secondary_key(
+        &self,
+        context: &WriteContext,
+        data: &[u8],
+        flags: u32,
+        timestamp: i64,
+        secondary_key: i64,
     ) -> Result<()> {
         let result = unsafe {
             nanots_writer_write(
@@ -273,8 +320,9 @@ impl Writer {
                 context.ptr,
                 data.as_ptr(),
                 data.len(),
-                timestamp,
                 flags,
+                timestamp,
+                secondary_key,
             )
         };
         let error_code = ErrorCode::from_c(result);
@@ -414,7 +462,9 @@ impl Reader {
 
     /// Read data from a stream in a time range
     ///
-    /// The callback receives: data slice, flags, timestamp, block_sequence, and metadata
+    /// The callback receives: data slice, flags, timestamp, secondary_key,
+    /// block_sequence, and metadata. `secondary_key` will be `SEC_KEY_UNSET`
+    /// for streams that don't store one.
     pub fn read<F>(
         &self,
         stream_tag: &str,
@@ -423,31 +473,36 @@ impl Reader {
         mut callback: F,
     ) -> Result<()>
     where
-        F: FnMut(&[u8], u8, i64, i64, &str),
+        F: FnMut(&[u8], u32, i64, i64, i64, &str),
     {
         let c_stream_tag = CString::new(stream_tag).map_err(|_| ErrorCode::InvalidArgument)?;
 
         extern "C" fn c_callback(
             data: *const u8,
             size: usize,
-            flags: u8,
+            flags: u32,
             timestamp: i64,
+            secondary_key: i64,
             block_sequence: i64,
             metadata: *const c_char,
             user_data: *mut c_void,
         ) {
-            let callback =
-                unsafe { &mut *(user_data as *mut &mut dyn FnMut(&[u8], u8, i64, i64, &str)) };
+            let callback = unsafe {
+                &mut *(user_data
+                    as *mut &mut dyn FnMut(&[u8], u32, i64, i64, i64, &str))
+            };
             let data_slice = unsafe { slice::from_raw_parts(data, size) };
             let metadata_str = if metadata.is_null() {
                 ""
             } else {
                 unsafe { CStr::from_ptr(metadata) }.to_str().unwrap_or("")
             };
-            callback(data_slice, flags, timestamp, block_sequence, metadata_str);
+            callback(
+                data_slice, flags, timestamp, secondary_key, block_sequence, metadata_str,
+            );
         }
 
-        let mut callback_ref: &mut dyn FnMut(&[u8], u8, i64, i64, &str) = &mut callback;
+        let mut callback_ref: &mut dyn FnMut(&[u8], u32, i64, i64, i64, &str) = &mut callback;
         let user_data = &mut callback_ref as *mut _ as *mut c_void;
 
         let result = unsafe {
@@ -577,6 +632,7 @@ impl Iterator {
             size: 0,
             flags: 0,
             timestamp: 0,
+            secondary_key: SEC_KEY_UNSET,
             block_sequence: 0,
         };
 
@@ -596,6 +652,7 @@ impl Iterator {
             data,
             flags: frame_info.flags,
             timestamp: frame_info.timestamp,
+            secondary_key: frame_info.secondary_key,
             block_sequence: frame_info.block_sequence,
         })
     }
@@ -642,6 +699,20 @@ impl Iterator {
         Ok(error_code == ErrorCode::Ok)
     }
 
+    /// Find the first frame at or after the given secondary key. Only valid
+    /// on streams whose [`has_secondary_key`](Self::has_secondary_key) is true.
+    pub fn find_by_secondary_key(&mut self, secondary_key: i64) -> Result<bool> {
+        let result =
+            unsafe { nanots_iterator_find_by_secondary_key(self.ptr, secondary_key) };
+        let error_code = ErrorCode::from_c(result);
+        Ok(error_code == ErrorCode::Ok)
+    }
+
+    /// True if this stream stores a secondary key on every frame.
+    pub fn has_secondary_key(&self) -> bool {
+        unsafe { nanots_iterator_has_secondary_key(self.ptr) != 0 }
+    }
+
     /// Reset to the first frame
     pub fn reset(&mut self) -> Result<()> {
         let result = unsafe { nanots_iterator_reset(self.ptr) };
@@ -669,8 +740,9 @@ impl Drop for Iterator {
 #[derive(Debug, Clone)]
 pub struct Frame {
     pub data: Vec<u8>,
-    pub flags: u8,
+    pub flags: u32,
     pub timestamp: i64,
+    pub secondary_key: i64,
     pub block_sequence: i64,
 }
 

--- a/bindings/nanots_python/README.md
+++ b/bindings/nanots_python/README.md
@@ -41,7 +41,7 @@ def nanots_basics_example():
             }).encode('utf-8')
             
             print("Writing data:", data.decode('utf-8'), "at", timestamp)
-            writer.write(write_context, data, timestamp, 0)
+            writer.write(write_context, data, 0, timestamp)
         
         # 3. READ DATA
         reader = nanots.Reader("test.nts")

--- a/bindings/nanots_python/nanots.pyx
+++ b/bindings/nanots_python/nanots.pyx
@@ -40,7 +40,9 @@ cdef extern from "nanots.h":
     ctypedef struct nanots_contiguous_segment_t:
         int segment_id
         int64_t start_timestamp
+        int64_t start_secondary_key
         int64_t end_timestamp
+        int64_t end_secondary_key
 
     ctypedef struct nanots_frame_info_t:
         const uint8_t* data
@@ -67,7 +69,9 @@ cdef extern from "nanots.h":
     nanots_ec_t nanots_writer_free_blocks(const char* file_name,
                                           const char* stream_tag,
                                           int64_t start_timestamp,
-                                          int64_t end_timestamp)
+                                          int64_t start_secondary_key,
+                                          int64_t end_timestamp,
+                                          int64_t end_secondary_key)
     nanots_ec_t nanots_writer_allocate_file(const char* file_name,
                                             uint32_t block_size,
                                             uint32_t n_blocks)
@@ -89,22 +93,28 @@ cdef extern from "nanots.h":
     nanots_ec_t nanots_reader_read(nanots_reader_t reader,
                                    const char* stream_tag,
                                    int64_t start_timestamp,
+                                   int64_t start_secondary_key,
                                    int64_t end_timestamp,
+                                   int64_t end_secondary_key,
                                    nanots_read_callback_t callback,
                                    void* user_data)
-    
+
     nanots_ec_t nanots_reader_query_contiguous_segments(
         nanots_reader_t reader,
         const char* stream_tag,
         int64_t start_timestamp,
+        int64_t start_secondary_key,
         int64_t end_timestamp,
+        int64_t end_secondary_key,
         nanots_contiguous_segment_t** segments,
         size_t* count)
     void nanots_free_contiguous_segments(nanots_contiguous_segment_t* segments)
-    
+
     nanots_ec_t nanots_reader_query_stream_tags_start(nanots_reader_t reader,
                                                       int64_t start_timestamp,
-                                                      int64_t end_timestamp)
+                                                      int64_t start_secondary_key,
+                                                      int64_t end_timestamp,
+                                                      int64_t end_secondary_key)
     const char* nanots_reader_query_stream_tags_next(nanots_reader_t reader)
     
     nanots_iterator_t nanots_iterator_create(const char* file_name,
@@ -123,9 +133,13 @@ cdef extern from "nanots.h":
     int64_t nanots_iterator_current_block_sequence(nanots_iterator_t iterator)
     const char* nanots_iterator_current_metadata(nanots_iterator_t iterator)
 
-# Sentinel for "this frame has no secondary key" (matches the C-level
-# NANOTS_SEC_KEY_UNSET = INT64_MIN).
+# Sentinel for "no secondary key" (matches the C-level
+# NANOTS_SEC_KEY_UNSET = INT64_MIN). The smallest possible secondary key.
 SEC_KEY_UNSET = -0x8000000000000000
+
+# Largest possible secondary key. Default upper bound for range queries
+# that don't want to constrain on sec_key.
+SEC_KEY_MAX = 0x7fffffffffffffff
 
 # Python exceptions
 class NanoTSError(Exception):
@@ -294,12 +308,22 @@ cdef class Writer:
         _check_result(result)
     
     @staticmethod
-    def free_blocks(str filename, str stream_tag, int64_t start_timestamp, int64_t end_timestamp):
-        """Free blocks for a time range in a stream."""
+    def free_blocks(str filename, str stream_tag,
+                    int64_t start_timestamp, int64_t end_timestamp,
+                    int64_t start_secondary_key=SEC_KEY_UNSET,
+                    int64_t end_secondary_key=SEC_KEY_MAX):
+        """Free blocks fully contained in the composite window
+        ``[(start_timestamp, start_secondary_key), (end_timestamp, end_secondary_key)]``.
+
+        Default sec_key bounds (``SEC_KEY_UNSET`` and ``SEC_KEY_MAX``) ignore
+        the sec_key axis — equivalent to a timestamp-only deletion.
+        """
         cdef bytes filename_bytes = filename.encode('utf-8')
         cdef bytes stream_tag_bytes = stream_tag.encode('utf-8')
         cdef nanots_ec_t result = nanots_writer_free_blocks(
-            filename_bytes, stream_tag_bytes, start_timestamp, end_timestamp)
+            filename_bytes, stream_tag_bytes,
+            start_timestamp, start_secondary_key,
+            end_timestamp, end_secondary_key)
         _check_result(result)
 
 # Reader wrapper
@@ -318,65 +342,75 @@ cdef class Reader:
         if self._reader != NULL:
             nanots_reader_destroy(self._reader)
     
-    def read(self, str stream_tag, int64_t start_timestamp, int64_t end_timestamp):
-        """Read data from the database, returning a list of frames."""
+    def read(self, str stream_tag,
+             int64_t start_timestamp, int64_t end_timestamp,
+             int64_t start_secondary_key=SEC_KEY_UNSET,
+             int64_t end_secondary_key=SEC_KEY_MAX):
+        """Read frames whose composite (timestamp, secondary_key) lies in
+        ``[(start_timestamp, start_secondary_key), (end_timestamp, end_secondary_key)]``.
+
+        Default sec_key bounds ignore the sec_key axis.
+        Returns a list of frame dicts.
+        """
         frames = []
-        
-        def callback(data, size, flags, timestamp, block_sequence, metadata):
-            # Copy data to Python bytes object
-            frame_data = data[:size]  # This creates a copy
-            frames.append({
-                'data': frame_data,
-                'timestamp': timestamp,
-                'flags': flags,
-                'block_sequence': block_sequence,
-                'metadata': metadata
-            })
-        
-        # Store callback in a place where the C code can find it
-        cdef object callback_ref = callback
-        
-        # For now, we'll use the simpler iterator approach
-        # The callback approach requires more complex Cython code
+
+        # We walk via the iterator (which already implements composite
+        # find()). End-of-range is a composite check.
         cdef Iterator iterator = Iterator(self._filename, stream_tag)
-        iterator.find(start_timestamp)
-        
+        iterator.find(start_timestamp, start_secondary_key)
+
         while iterator.valid():
             frame = iterator.get_current_frame()
-            if frame['timestamp'] > end_timestamp:
+            ts = frame['timestamp']
+            sk = frame['secondary_key']
+            if ts > end_timestamp or (ts == end_timestamp and sk > end_secondary_key):
                 break
             frames.append(frame)
             iterator.next()
-        
+
         return frames
-    
-    def query_contiguous_segments(self, str stream_tag, int64_t start_timestamp, int64_t end_timestamp):
-        """Query contiguous segments in a time range."""
+
+    def query_contiguous_segments(self, str stream_tag,
+                                  int64_t start_timestamp, int64_t end_timestamp,
+                                  int64_t start_secondary_key=SEC_KEY_UNSET,
+                                  int64_t end_secondary_key=SEC_KEY_MAX):
+        """Query contiguous block runs within the composite window. Default
+        sec_key bounds ignore the sec_key axis."""
         cdef bytes stream_tag_bytes = stream_tag.encode('utf-8')
         cdef nanots_contiguous_segment_t* segments = NULL
         cdef size_t count = 0
-        
+
         cdef nanots_ec_t result = nanots_reader_query_contiguous_segments(
-            self._reader, stream_tag_bytes, start_timestamp, end_timestamp, &segments, &count)
+            self._reader, stream_tag_bytes,
+            start_timestamp, start_secondary_key,
+            end_timestamp, end_secondary_key,
+            &segments, &count)
         _check_result(result)
-        
+
         # Convert to Python list
         segment_list = []
         for i in range(count):
             segment_list.append({
                 'segment_id': segments[i].segment_id,
                 'start_timestamp': segments[i].start_timestamp,
-                'end_timestamp': segments[i].end_timestamp
+                'start_secondary_key': segments[i].start_secondary_key,
+                'end_timestamp': segments[i].end_timestamp,
+                'end_secondary_key': segments[i].end_secondary_key
             })
-        
+
         # Free the C memory
         nanots_free_contiguous_segments(segments)
         return segment_list
-    
-    def query_stream_tags(self, int64_t start_timestamp, int64_t end_timestamp):
-        """Query all stream tags that exist in the given time range."""
+
+    def query_stream_tags(self, int64_t start_timestamp, int64_t end_timestamp,
+                          int64_t start_secondary_key=SEC_KEY_UNSET,
+                          int64_t end_secondary_key=SEC_KEY_MAX):
+        """Query distinct stream tags that overlap the composite window.
+        Default sec_key bounds ignore the sec_key axis."""
         cdef nanots_ec_t result = nanots_reader_query_stream_tags_start(
-            self._reader, start_timestamp, end_timestamp)
+            self._reader,
+            start_timestamp, start_secondary_key,
+            end_timestamp, end_secondary_key)
         _check_result(result)
         
         # Collect all stream tags

--- a/bindings/nanots_python/nanots.pyx
+++ b/bindings/nanots_python/nanots.pyx
@@ -34,19 +34,24 @@ cdef extern from "nanots.h":
         NANOTS_EC_INVALID_ARGUMENT = 11
         NANOTS_EC_UNKNOWN = 12
         NANOTS_EC_NOT_FOUND = 13
-    
+        NANOTS_EC_BAD_MAGIC = 14
+        NANOTS_EC_BAD_VERSION = 15
+        NANOTS_EC_SECONDARY_KEY_MISMATCH = 16
+        NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY = 17
+
     ctypedef struct nanots_contiguous_segment_t:
         int segment_id
         int64_t start_timestamp
         int64_t end_timestamp
-    
+
     ctypedef struct nanots_frame_info_t:
         const uint8_t* data
         size_t size
-        uint8_t flags
+        uint32_t flags
         int64_t timestamp
+        int64_t secondary_key
         int64_t block_sequence
-    
+
     # Function declarations
     nanots_writer_t nanots_writer_create(const char* file_name, int auto_reclaim)
     void nanots_writer_destroy(nanots_writer_t writer)
@@ -58,8 +63,9 @@ cdef extern from "nanots.h":
                                     nanots_write_context_t context,
                                     const uint8_t* data,
                                     size_t size,
+                                    uint32_t flags,
                                     int64_t timestamp,
-                                    uint8_t flags)
+                                    int64_t secondary_key)
     nanots_ec_t nanots_writer_free_blocks(const char* file_name,
                                           const char* stream_tag,
                                           int64_t start_timestamp,
@@ -75,8 +81,9 @@ cdef extern from "nanots.h":
     void nanots_reader_destroy(nanots_reader_t reader)
     ctypedef void (*nanots_read_callback_t)(const uint8_t* data,
                                            size_t size,
-                                           uint8_t flags,
+                                           uint32_t flags,
                                            int64_t timestamp,
+                                           int64_t secondary_key,
                                            int64_t block_sequence,
                                            const char* metadata,
                                            void* user_data)
@@ -113,9 +120,16 @@ cdef extern from "nanots.h":
     nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator)
     nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
                                      int64_t timestamp)
+    nanots_ec_t nanots_iterator_find_by_secondary_key(nanots_iterator_t iterator,
+                                                     int64_t secondary_key)
+    int nanots_iterator_has_secondary_key(nanots_iterator_t iterator)
     nanots_ec_t nanots_iterator_reset(nanots_iterator_t iterator)
     int64_t nanots_iterator_current_block_sequence(nanots_iterator_t iterator)
     const char* nanots_iterator_current_metadata(nanots_iterator_t iterator)
+
+# Sentinel for "this frame has no secondary key" (matches the C-level
+# NANOTS_SEC_KEY_UNSET = INT64_MIN).
+SEC_KEY_UNSET = -0x8000000000000000
 
 # Python exceptions
 class NanoTSError(Exception):
@@ -157,6 +171,18 @@ class InvalidArgumentError(NanoTSError):
 class NotFoundError(NanoTSError):
     pass
 
+class BadMagicError(NanoTSError):
+    pass
+
+class BadVersionError(NanoTSError):
+    pass
+
+class SecondaryKeyMismatchError(NanoTSError):
+    pass
+
+class NonMonotonicSecondaryKeyError(NanoTSError):
+    pass
+
 # Helper function to check results and raise appropriate exceptions
 cdef void _check_result(nanots_ec_t result):
     if result == NANOTS_EC_OK:
@@ -185,6 +211,14 @@ cdef void _check_result(nanots_ec_t result):
         raise InvalidArgumentError("Invalid argument")
     elif result == NANOTS_EC_NOT_FOUND:
         raise NotFoundError("Not found")
+    elif result == NANOTS_EC_BAD_MAGIC:
+        raise BadMagicError("Not a nanots v2 file (bad magic)")
+    elif result == NANOTS_EC_BAD_VERSION:
+        raise BadVersionError("Unsupported nanots format version")
+    elif result == NANOTS_EC_SECONDARY_KEY_MISMATCH:
+        raise SecondaryKeyMismatchError("Stream secondary-key mode mismatch")
+    elif result == NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY:
+        raise NonMonotonicSecondaryKeyError("Secondary key must be monotonic")
     else:
         raise NanoTSError(f"Unknown error: {result}")
 
@@ -255,10 +289,20 @@ cdef class Writer:
             raise NanoTSError("Failed to create write context")
         return context
     
-    def write(self, WriteContext context, bytes data, int64_t timestamp, uint8_t flags=0):
-        """Write data to the database."""
+    def write(self, WriteContext context, bytes data,
+              uint32_t flags, int64_t timestamp,
+              int64_t secondary_key=SEC_KEY_UNSET):
+        """Write data to the database.
+
+        Pass ``secondary_key`` to write into a stream that uses a secondary
+        key (the choice is fixed by the first write to that stream tag).
+        Default ``SEC_KEY_UNSET`` writes into an unkeyed stream. Any other
+        value — including 0 — counts as a real key and locks the stream as
+        keyed.
+        """
         cdef nanots_ec_t result = nanots_writer_write(
-            self._writer, context._context, data, len(data), timestamp, flags)
+            self._writer, context._context, data, len(data),
+            flags, timestamp, secondary_key)
         _check_result(result)
     
     @staticmethod
@@ -387,18 +431,19 @@ cdef class Iterator:
         """Get the current frame data."""
         if not self.valid():
             raise NanoTSError("Iterator not at valid position")
-        
+
         cdef nanots_frame_info_t frame_info
         cdef nanots_ec_t result = nanots_iterator_get_current_frame(
             self._iterator, &frame_info)
         _check_result(result)
-        
+
         # Copy the data to a Python bytes object
         cdef bytes data = frame_info.data[:frame_info.size]
-        
+
         return {
             'data': data,
             'timestamp': frame_info.timestamp,
+            'secondary_key': frame_info.secondary_key,
             'flags': frame_info.flags,
             'block_sequence': frame_info.block_sequence,
             'metadata': self.current_metadata()
@@ -418,6 +463,20 @@ cdef class Iterator:
         """Find frame at or after given timestamp."""
         cdef nanots_ec_t result = nanots_iterator_find(self._iterator, timestamp)
         _check_result(result)
+
+    def find_by_secondary_key(self, int64_t secondary_key):
+        """Find first frame at or after the given secondary key.
+
+        Only valid on streams that store a secondary key. Returns False if
+        no such frame exists (and invalidates the iterator).
+        """
+        cdef nanots_ec_t result = nanots_iterator_find_by_secondary_key(
+            self._iterator, secondary_key)
+        return result == NANOTS_EC_OK
+
+    def has_secondary_key(self):
+        """True if this stream stores a secondary key on every frame."""
+        return nanots_iterator_has_secondary_key(self._iterator) != 0
     
     def reset(self):
         """Reset iterator to beginning."""

--- a/bindings/nanots_python/nanots.pyx
+++ b/bindings/nanots_python/nanots.pyx
@@ -36,8 +36,6 @@ cdef extern from "nanots.h":
         NANOTS_EC_NOT_FOUND = 13
         NANOTS_EC_BAD_MAGIC = 14
         NANOTS_EC_BAD_VERSION = 15
-        NANOTS_EC_SECONDARY_KEY_MISMATCH = 16
-        NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY = 17
 
     ctypedef struct nanots_contiguous_segment_t:
         int segment_id
@@ -119,10 +117,8 @@ cdef extern from "nanots.h":
     nanots_ec_t nanots_iterator_next(nanots_iterator_t iterator)
     nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator)
     nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
-                                     int64_t timestamp)
-    nanots_ec_t nanots_iterator_find_by_secondary_key(nanots_iterator_t iterator,
-                                                     int64_t secondary_key)
-    int nanots_iterator_has_secondary_key(nanots_iterator_t iterator)
+                                     int64_t timestamp,
+                                     int64_t secondary_key)
     nanots_ec_t nanots_iterator_reset(nanots_iterator_t iterator)
     int64_t nanots_iterator_current_block_sequence(nanots_iterator_t iterator)
     const char* nanots_iterator_current_metadata(nanots_iterator_t iterator)
@@ -177,12 +173,6 @@ class BadMagicError(NanoTSError):
 class BadVersionError(NanoTSError):
     pass
 
-class SecondaryKeyMismatchError(NanoTSError):
-    pass
-
-class NonMonotonicSecondaryKeyError(NanoTSError):
-    pass
-
 # Helper function to check results and raise appropriate exceptions
 cdef void _check_result(nanots_ec_t result):
     if result == NANOTS_EC_OK:
@@ -215,10 +205,6 @@ cdef void _check_result(nanots_ec_t result):
         raise BadMagicError("Not a nanots v2 file (bad magic)")
     elif result == NANOTS_EC_BAD_VERSION:
         raise BadVersionError("Unsupported nanots format version")
-    elif result == NANOTS_EC_SECONDARY_KEY_MISMATCH:
-        raise SecondaryKeyMismatchError("Stream secondary-key mode mismatch")
-    elif result == NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY:
-        raise NonMonotonicSecondaryKeyError("Secondary key must be monotonic")
     else:
         raise NanoTSError(f"Unknown error: {result}")
 
@@ -294,11 +280,13 @@ cdef class Writer:
               int64_t secondary_key=SEC_KEY_UNSET):
         """Write data to the database.
 
-        Pass ``secondary_key`` to write into a stream that uses a secondary
-        key (the choice is fixed by the first write to that stream tag).
-        Default ``SEC_KEY_UNSET`` writes into an unkeyed stream. Any other
-        value — including 0 — counts as a real key and locks the stream as
-        keyed.
+        Frames are ordered by the composite ``(timestamp, secondary_key)``,
+        which must strictly increase across writes. Default
+        ``secondary_key=SEC_KEY_UNSET`` (= INT64_MIN) makes the composite
+        check degenerate to "timestamp strictly increasing", so callers who
+        don't need a tiebreaker don't have to think about it. Pass any
+        other ``int64`` to disambiguate frames at the same timestamp — the
+        ``int64`` sequence per timestamp must strictly increase.
         """
         cdef nanots_ec_t result = nanots_writer_write(
             self._writer, context._context, data, len(data),
@@ -459,24 +447,18 @@ cdef class Iterator:
         cdef nanots_ec_t result = nanots_iterator_prev(self._iterator)
         _check_result(result)
     
-    def find(self, int64_t timestamp):
-        """Find frame at or after given timestamp."""
-        cdef nanots_ec_t result = nanots_iterator_find(self._iterator, timestamp)
-        _check_result(result)
+    def find(self, int64_t timestamp,
+             int64_t secondary_key=SEC_KEY_UNSET):
+        """Find the first frame whose composite (timestamp, secondary_key)
+        is >= the requested composite.
 
-    def find_by_secondary_key(self, int64_t secondary_key):
-        """Find first frame at or after the given secondary key.
-
-        Only valid on streams that store a secondary key. Returns False if
-        no such frame exists (and invalidates the iterator).
+        Pass ``secondary_key`` to seek to a specific tiebroken position
+        within a timestamp; omit it (defaults to ``SEC_KEY_UNSET``) to land
+        on the first frame at the requested timestamp regardless of sec_key.
         """
-        cdef nanots_ec_t result = nanots_iterator_find_by_secondary_key(
-            self._iterator, secondary_key)
-        return result == NANOTS_EC_OK
-
-    def has_secondary_key(self):
-        """True if this stream stores a secondary key on every frame."""
-        return nanots_iterator_has_secondary_key(self._iterator) != 0
+        cdef nanots_ec_t result = nanots_iterator_find(
+            self._iterator, timestamp, secondary_key)
+        _check_result(result)
     
     def reset(self):
         """Reset iterator to beginning."""

--- a/bindings/nanots_python/tests/basics/test_growable.py
+++ b/bindings/nanots_python/tests/basics/test_growable.py
@@ -32,7 +32,7 @@ def growable_example():
         payload = bytes(i & 0xff for i in range(block_size // 2))
 
         for i in range(1, 9):
-            writer.write(ctx, payload, i * 1000, 0)
+            writer.write(ctx, payload, 0, i * 1000)
             print(f"  file size after write {i}: {os.path.getsize(db_file):6d} bytes")
 
         # Drop the writer/ctx explicitly so their destructors run (flushing

--- a/bindings/nanots_python/tests/basics/test_nanots.py
+++ b/bindings/nanots_python/tests/basics/test_nanots.py
@@ -30,7 +30,7 @@ def nanots_basics_example():
             }).encode('utf-8')
             
             print("Writing data:", data.decode('utf-8'), "at", timestamp)
-            writer.write(context, data, timestamp, 0)
+            writer.write(context, data, 0, timestamp)
         
         # 3. READ DATA
         reader = nanots.Reader(db_file)

--- a/bindings/nanots_python/tests/finance/test_finance_parallel.py
+++ b/bindings/nanots_python/tests/finance/test_finance_parallel.py
@@ -176,9 +176,9 @@ class ParallelNanoTSStressTest:
                     trade_data = struct.pack('if', record['trades'], record['volume'])
                     
                     # Write to different contexts with unique stream tags
-                    writer.write(price_context, price_data, record['timestamp'], price_tag)
-                    writer.write(volume_context, volume_data, record['timestamp'], volume_tag)
-                    writer.write(trade_context, trade_data, record['timestamp'], trade_tag)
+                    writer.write(price_context, price_data, price_tag, record['timestamp'])
+                    writer.write(volume_context, volume_data, volume_tag, record['timestamp'])
+                    writer.write(trade_context, trade_data, trade_tag, record['timestamp'])
                     
                     write_time = time.time() - write_start
                     

--- a/nanots.cpp
+++ b/nanots.cpp
@@ -153,16 +153,20 @@ static uint32_t _round_to_64k_boundary(uint32_t requested_size) {
 
 static bool _validate_frame_header(const uint8_t* frame_p,
                                    const uint8_t* expected_uuid,
-                                   uint8_t* flags_out,
-                                   uint32_t* size_out) {
+                                   uint32_t* flags_out,
+                                   uint32_t* size_out,
+                                   int64_t* sec_key_out) {
   if (memcmp(frame_p + FRAME_UUID_OFFSET, expected_uuid, 16) != 0)
     return false;
+
+  if (sec_key_out)
+    *sec_key_out = *(int64_t*)(frame_p + FRAME_SECKEY_OFFSET);
 
   if (size_out)
     *size_out = *(uint32_t*)(frame_p + FRAME_SIZE_OFFSET);
 
   if (flags_out)
-    *flags_out = *(frame_p + FRAME_FLAGS_OFFSET);
+    *flags_out = *(uint32_t*)(frame_p + FRAME_FLAGS_OFFSET);
 
   return true;
 }
@@ -180,35 +184,35 @@ static void _free_block(nts_sqlite_conn& conn, int sb_id, int block_id) {
   });
 }
 
-static bool _is_valid_frame_at_index(uint8_t* block_p, uint32_t block_size, 
-                                     int index, uint32_t n_valid_indexes, 
+static bool _is_valid_frame_at_index(uint8_t* block_p, uint32_t block_size,
+                                     int index, uint32_t n_valid_indexes,
                                      const uint8_t* uuid) {
   uint8_t* index_p = block_p + BLOCK_HEADER_SIZE + (index * INDEX_ENTRY_SIZE);
-  int64_t timestamp = *(int64_t*)index_p;
-  uint64_t offset = *(uint64_t*)(index_p + 8);
+  int64_t timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+  uint64_t offset = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
   // Skip zeroed entries
   if (timestamp == 0 || offset == 0) {
     return false;
   }
-  
+
   // Check frame offset bounds
   uint32_t index_region_end = BLOCK_HEADER_SIZE + ((n_valid_indexes + 1) * INDEX_ENTRY_SIZE);
   if (offset < index_region_end || offset > block_size - FRAME_HEADER_SIZE) {
     return false;
   }
-  
+
   // Validate frame header
   uint32_t frame_size = 0;
-  if (!_validate_frame_header(block_p + offset, uuid, nullptr, &frame_size)) {
+  if (!_validate_frame_header(block_p + offset, uuid, nullptr, &frame_size, nullptr)) {
     return false;
   }
-  
+
   // Check if frame size fits within block
   if (frame_size > block_size - offset - FRAME_HEADER_SIZE) {
     return false;
   }
-  
+
   return true;
 }
 
@@ -226,7 +230,13 @@ static void _validate_blocks(const std::string& file_name) {
         nts_memory_map::NMM_PROT_READ | nts_memory_map::NMM_PROT_WRITE,
         nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED);
 
-    block_size = *(uint32_t*)mm.map();
+    uint8_t* hp = (uint8_t*)mm.map();
+    if (memcmp(hp + FILE_HEADER_MAGIC_OFFSET, NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN) != 0)
+      throw nanots_exception(NANOTS_EC_BAD_MAGIC, "Not a nanots v2 file (bad magic).", __FILE__, __LINE__);
+    uint16_t version = *(uint16_t*)(hp + FILE_HEADER_VERSION_OFFSET);
+    if (version != NANOTS_FORMAT_VERSION)
+      throw nanots_exception(NANOTS_EC_BAD_VERSION, "Unsupported nanots format version.", __FILE__, __LINE__);
+    block_size = *(uint32_t*)(hp + FILE_HEADER_BLOCK_SIZE_OFFSET);
   }
 
   auto db_name = _database_name(file_name);
@@ -303,13 +313,15 @@ static void _validate_blocks(const std::string& file_name) {
         nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
           uint8_t* last_index_p =
               block_p + BLOCK_HEADER_SIZE + (last_valid * INDEX_ENTRY_SIZE);
-          int64_t actual_last_timestamp = *(int64_t*)last_index_p;
+          int64_t actual_last_timestamp = *(int64_t*)(last_index_p + INDEX_ENTRY_TS_OFFSET);
+          int64_t actual_last_sk = *(int64_t*)(last_index_p + INDEX_ENTRY_SECKEY_OFFSET);
           auto stmt = conn.prepare(
-              "UPDATE segment_blocks SET end_timestamp = ? WHERE block_idx = ? AND uuid "
-              "= ?");
+              "UPDATE segment_blocks SET end_timestamp = ?, end_secondary_key = ? "
+              "WHERE block_idx = ? AND uuid = ?");
           stmt.bind(1, actual_last_timestamp)
-              .bind(2, block_idx)
-              .bind(3, uuid_hex)
+              .bind(2, actual_last_sk)
+              .bind(3, block_idx)
+              .bind(4, uuid_hex)
               .exec_no_result();
         });
       }
@@ -334,10 +346,18 @@ static void _set_db_version(const nts_sqlite_conn& conn, int version) {
 static void _upgrade_db(const nts_sqlite_conn& conn) {
   auto current_version = _get_db_version(conn);
 
+  // v2-only build: any pre-v2 database is rejected. (Fresh DBs created by
+  // allocate() are stamped to version 2 below.)
+  if (current_version != 0 && current_version < 2) {
+    throw nanots_exception(NANOTS_EC_BAD_VERSION,
+                           "Legacy nanots catalog (pre-v2) is not supported.",
+                           __FILE__, __LINE__);
+  }
+
   switch (current_version) {
     case 0: {
       nts_sqlite_transaction(
-          conn, true, [&](const nts_sqlite_conn& conn) { _set_db_version(conn, 1); });
+          conn, true, [&](const nts_sqlite_conn& conn) { _set_db_version(conn, 2); });
     }
       [[fallthrough]];
     default:
@@ -397,14 +417,36 @@ static std::optional<block> _db_get_free_block(const nts_sqlite_conn& conn) {
 //  which composes _db_get_free_block / _grow_blocks / _db_reclaim_oldest_used_block
 //  with the EBR limbo/ready machinery.)
 
+// Look up whether any existing segment for this stream tag uses the secondary
+// key. Returns nullopt if no segment exists yet for this stream (caller's
+// choice will become the canonical one), or the 0/1 value otherwise.
+static std::optional<int> _db_lookup_stream_has_secondary_key(
+    const nts_sqlite_conn& conn, const std::string& stream_tag) {
+  auto stmt = conn.prepare(
+      "SELECT has_secondary_key FROM segments WHERE stream_tag = ? LIMIT 1");
+  auto rows = stmt.bind(1, stream_tag).exec();
+  if (rows.empty()) return std::nullopt;
+  return std::stoi(rows.front()["has_secondary_key"].value());
+}
+
 static std::optional<segment> _db_create_segment(const nts_sqlite_conn& conn,
                                                  const std::string& stream_tag,
-                                                 const std::string& metadata) {
-  auto stmt =
-      conn.prepare("INSERT INTO segments (stream_tag, metadata) VALUES (?, ?)");
-  stmt.bind(1, stream_tag).bind(2, metadata).exec_no_result();
+                                                 const std::string& metadata,
+                                                 bool has_secondary_key) {
+  auto stmt = conn.prepare(
+      "INSERT INTO segments (stream_tag, metadata, has_secondary_key) VALUES (?, ?, ?)");
+  stmt.bind(1, stream_tag)
+      .bind(2, metadata)
+      .bind(3, has_secondary_key ? 1 : 0)
+      .exec_no_result();
 
-  return segment{std::stoll(conn.last_insert_id()), stream_tag, metadata, 0};
+  segment s;
+  s.id = std::stoll(conn.last_insert_id());
+  s.stream_tag = stream_tag;
+  s.metadata = metadata;
+  s.sequence = 0;
+  s.has_secondary_key = has_secondary_key;
+  return s;
 }
 
 static std::optional<segment_block> _db_create_segment_block(
@@ -415,6 +457,8 @@ static std::optional<segment_block> _db_create_segment_block(
     int64_t block_idx,
     int64_t start_timestamp,
     int64_t end_timestamp,
+    int64_t start_secondary_key,
+    int64_t end_secondary_key,
     const uint8_t* uuid) {
   auto stmt = conn.prepare(
       "INSERT INTO segment_blocks ("
@@ -424,8 +468,10 @@ static std::optional<segment_block> _db_create_segment_block(
       "block_idx, "
       "start_timestamp, "
       "end_timestamp, "
+      "start_secondary_key, "
+      "end_secondary_key, "
       "uuid"
-      ") VALUES (?, ?, ?, ?, ?, ?, ?)");
+      ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
   auto hex_uuid = entropy_id_to_s(uuid);
 
@@ -435,7 +481,9 @@ static std::optional<segment_block> _db_create_segment_block(
       .bind(4, block_idx)
       .bind(5, start_timestamp)
       .bind(6, end_timestamp)
-      .bind(7, hex_uuid)
+      .bind(7, start_secondary_key)
+      .bind(8, end_secondary_key)
+      .bind(9, hex_uuid)
       .exec_no_result();
 
   struct segment_block sb;
@@ -446,6 +494,8 @@ static std::optional<segment_block> _db_create_segment_block(
   sb.block_idx = block_idx;
   sb.start_timestamp = start_timestamp;
   sb.end_timestamp = end_timestamp;
+  sb.start_secondary_key = start_secondary_key;
+  sb.end_secondary_key = end_secondary_key;
   memcpy(sb.uuid, uuid, 16);
 
   return sb;
@@ -453,9 +503,15 @@ static std::optional<segment_block> _db_create_segment_block(
 
 static void _db_finalize_block(const nts_sqlite_conn& conn,
                                int64_t segment_block_id,
-                               int64_t timestamp) {
-  auto stmt = conn.prepare("UPDATE segment_blocks SET end_timestamp = ? WHERE id = ?");
-  stmt.bind(1, timestamp).bind(2, segment_block_id).exec_no_result();
+                               int64_t timestamp,
+                               int64_t secondary_key) {
+  auto stmt = conn.prepare(
+      "UPDATE segment_blocks SET end_timestamp = ?, end_secondary_key = ? "
+      "WHERE id = ?");
+  stmt.bind(1, timestamp)
+      .bind(2, secondary_key)
+      .bind(3, segment_block_id)
+      .exec_no_result();
 }
 
 static void _db_trans_finalize_reserved_blocks(const nts_sqlite_conn& conn) {
@@ -512,8 +568,10 @@ write_context::~write_context() {
     auto db_name = _database_name(file_name);
     nts_sqlite_conn conn(db_name, true, true);
 
+    int64_t end_sk = last_secondary_key.value_or(NANOTS_SEC_KEY_UNSET);
+
     nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-      _db_finalize_block(conn, current_block->id, last_timestamp.value());
+      _db_finalize_block(conn, current_block->id, last_timestamp.value(), end_sk);
       // This is a maintenance task that needs to be done periodically.
       _db_trans_finalize_reserved_blocks(conn);
     });
@@ -531,16 +589,24 @@ nanots_writer::nanots_writer(const std::string& file_name, bool auto_reclaim)
           nts_memory_map::NMM_PROT_READ | nts_memory_map::NMM_PROT_WRITE,
           nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED),
       _file_header_p((uint8_t*)_file_header_mm.map()),
-      _block_size(*(uint32_t*)_file_header_p),
-      _n_blocks(*(uint32_t*)(_file_header_p + sizeof(uint32_t))),
-      // max_blocks lives at offset 8. For legacy preallocated files this byte
-      // range was zeroed by fallocate (Linux/macOS) or left at whatever
-      // SetEndOfFile produced (Windows). Only consulted in growable mode, and
-      // new allocate() always writes 0 here, so legacy preallocated files are
-      // unaffected.
-      _max_blocks(*(uint32_t*)(_file_header_p + 8)),
+      _block_size(*(uint32_t*)(_file_header_p + FILE_HEADER_BLOCK_SIZE_OFFSET)),
+      _n_blocks(*(uint32_t*)(_file_header_p + FILE_HEADER_N_BLOCKS_OFFSET)),
+      _max_blocks(*(uint32_t*)(_file_header_p + FILE_HEADER_MAX_BLOCKS_OFFSET)),
       _auto_reclaim(auto_reclaim),
       _epoch(nanots_epoch_registry::get_or_create(file_name)) {
+  // Validate v2 magic + version up front. Legacy v1 files (which had
+  // block_size at offset 0) are rejected by design.
+  if (memcmp(_file_header_p + FILE_HEADER_MAGIC_OFFSET,
+             NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN) != 0)
+    throw nanots_exception(NANOTS_EC_BAD_MAGIC,
+                           "Not a nanots v2 file (bad magic). Legacy v1 files are not supported.",
+                           __FILE__, __LINE__);
+  uint16_t version = *(uint16_t*)(_file_header_p + FILE_HEADER_VERSION_OFFSET);
+  if (version != NANOTS_FORMAT_VERSION)
+    throw nanots_exception(NANOTS_EC_BAD_VERSION,
+                           "Unsupported nanots format version.",
+                           __FILE__, __LINE__);
+
   if (_block_size < 4096 || _block_size > 1024 * 1024 * 1024)
     throw nanots_exception(NANOTS_EC_INVALID_BLOCK_SIZE, "Invalid block size in file header.", __FILE__, __LINE__);
 
@@ -605,7 +671,7 @@ write_context nanots_writer::create_write_context(const std::string& stream_tag,
                                                   const std::string& metadata) {
 
   std::string key = _file_name + ":" + stream_tag;
-  
+
   std::lock_guard<std::mutex> g(current_stream_tags_lok);
   if(current_stream_tags.find(key) != current_stream_tags.end())
     throw nanots_exception(NANOTS_EC_DUPLICATE_STREAM_TAG, "Only one current writer per active stream tag.", __FILE__, __LINE__);
@@ -616,15 +682,9 @@ write_context nanots_writer::create_write_context(const std::string& stream_tag,
   wctx.file_name = _file_name;
   wctx._block_size = _block_size;
 
-  auto db_name = _database_name(_file_name);
-
-  nts_sqlite_conn conn(db_name.c_str(), true, true);
-
-  nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-    wctx.current_segment = _db_create_segment(conn, stream_tag, metadata);
-    if (!wctx.current_segment)
-      throw nanots_exception(NANOTS_EC_UNABLE_TO_CREATE_SEGMENT, "Unable to create segment.", __FILE__, __LINE__);
-  });
+  // Segment creation is deferred to the first write(): only then do we know
+  // whether the caller intends this stream to carry a secondary key, which
+  // is recorded permanently on the segments row.
 
   current_stream_tags.insert(key);
 
@@ -722,14 +782,59 @@ block nanots_writer::_acquire_writable_block(const nts_sqlite_conn& conn) {
 void nanots_writer::write(write_context& wctx,
                           const uint8_t* data,
                           size_t size,
+                          uint32_t flags,
                           int64_t timestamp,
-                          uint8_t flags) {
+                          int64_t secondary_key) {
   if (wctx.last_timestamp && timestamp <= wctx.last_timestamp.value())
     throw nanots_exception(NANOTS_EC_NON_MONOTONIC_TIMESTAMP, "Timestamp is not monotonic.", __FILE__, __LINE__);
 
   if (size >
       _block_size - (FRAME_HEADER_SIZE + INDEX_ENTRY_SIZE + BLOCK_HEADER_SIZE))
     throw nanots_exception(NANOTS_EC_ROW_SIZE_TOO_BIG, "Frame size is too large. Use a much larger block size.", __FILE__, __LINE__);
+
+  // First write to this context: lazily create (or attach to) the segment
+  // row. The very first write to a brand-new stream tag fixes the choice of
+  // whether the stream stores a secondary key on every frame.
+  if (!wctx.current_segment) {
+    bool wants_sec_key = (secondary_key != NANOTS_SEC_KEY_UNSET);
+
+    nts_sqlite_conn conn(_database_name(_file_name), true, true);
+    nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
+      auto existing = _db_lookup_stream_has_secondary_key(conn, wctx.stream_tag);
+      if (existing.has_value()) {
+        bool existing_yes = (*existing != 0);
+        if (existing_yes != wants_sec_key) {
+          throw nanots_exception(
+              NANOTS_EC_SECONDARY_KEY_MISMATCH,
+              "Stream's secondary-key mode is fixed by its first write and "
+              "this write does not match.", __FILE__, __LINE__);
+        }
+      }
+      wctx.current_segment = _db_create_segment(
+          conn, wctx.stream_tag, wctx.metadata, wants_sec_key);
+      if (!wctx.current_segment)
+        throw nanots_exception(NANOTS_EC_UNABLE_TO_CREATE_SEGMENT, "Unable to create segment.", __FILE__, __LINE__);
+    });
+  } else {
+    // Subsequent writes: enforce the per-stream choice that was locked in
+    // on the first write.
+    bool stream_wants = wctx.current_segment->has_secondary_key;
+    bool this_write_provides = (secondary_key != NANOTS_SEC_KEY_UNSET);
+    if (stream_wants != this_write_provides) {
+      throw nanots_exception(
+          NANOTS_EC_SECONDARY_KEY_MISMATCH,
+          "Stream's secondary-key mode is fixed and this write does not match.",
+          __FILE__, __LINE__);
+    }
+  }
+
+  if (secondary_key != NANOTS_SEC_KEY_UNSET &&
+      wctx.last_secondary_key.has_value() &&
+      secondary_key <= wctx.last_secondary_key.value()) {
+    throw nanots_exception(NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY,
+                           "Secondary key is not monotonic.",
+                           __FILE__, __LINE__);
+  }
 
   if (!wctx.current_block) {
     nts_sqlite_conn conn(_database_name(_file_name), true, true);
@@ -747,7 +852,7 @@ void nanots_writer::write(write_context& wctx,
 
       wctx.current_block = _db_create_segment_block(
           conn, wctx.current_segment->id, wctx.current_segment->sequence,
-          phys.id, phys.idx, timestamp, 0, uuid);
+          phys.id, phys.idx, timestamp, 0, secondary_key, 0, uuid);
 
       if (!wctx.current_block)
         throw nanots_exception(NANOTS_EC_UNABLE_TO_CREATE_SEGMENT_BLOCK, "Unable to create segment block.", __FILE__, __LINE__);
@@ -783,7 +888,7 @@ void nanots_writer::write(write_context& wctx,
   if (n_valid_indexes > 0) {
     uint8_t* last_index_p = block_p + BLOCK_HEADER_SIZE +
                             ((n_valid_indexes - 1) * INDEX_ENTRY_SIZE);
-    uint64_t last_frame_offset = *(uint64_t*)(last_index_p + 8);
+    uint64_t last_frame_offset = *(uint64_t*)(last_index_p + INDEX_ENTRY_OFFSET_OFFSET);
     if (last_frame_offset >= padded_frame_size) {
       uint64_t candidate_ofs = last_frame_offset - padded_frame_size;
       new_block_ofs = (candidate_ofs >= index_end) ? candidate_ofs : index_end;
@@ -797,26 +902,31 @@ void nanots_writer::write(write_context& wctx,
 
     wctx.mm.flush(wctx.mm.map(), _block_size, true);
 
+    int64_t end_sk = wctx.last_secondary_key.value_or(NANOTS_SEC_KEY_UNSET);
     nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-      _db_finalize_block(conn, wctx.current_block->id, wctx.last_timestamp.value());
+      _db_finalize_block(conn, wctx.current_block->id,
+                         wctx.last_timestamp.value(), end_sk);
     });
 
     wctx.current_block = std::nullopt;
     wctx.mm = nts_memory_map();
 
-    return write(wctx, data, size, timestamp, flags);
+    return write(wctx, data, size, flags, timestamp, secondary_key);
   }
 
   uint8_t* frame_p = block_p + new_block_ofs;
-  memcpy(frame_p, wctx.current_block->uuid, 16);
-  *(uint32_t*)(frame_p + 16) = (uint32_t)size;
-  *(frame_p + 20) = flags;
+  memcpy(frame_p + FRAME_UUID_OFFSET, wctx.current_block->uuid, 16);
+  *(int64_t*)(frame_p + FRAME_SECKEY_OFFSET) = secondary_key;
+  *(uint32_t*)(frame_p + FRAME_SIZE_OFFSET) = (uint32_t)size;
+  *(uint32_t*)(frame_p + FRAME_FLAGS_OFFSET) = flags;
   memcpy(frame_p + FRAME_HEADER_SIZE, data, size);
 
   uint8_t* index_p =
       block_p + BLOCK_HEADER_SIZE + (n_valid_indexes * INDEX_ENTRY_SIZE);
-  *(int64_t*)index_p = timestamp;
-  *(uint64_t*)(index_p + 8) = new_block_ofs;
+  *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET) = timestamp;
+  *(int64_t*)(index_p + INDEX_ENTRY_SECKEY_OFFSET) = secondary_key;
+  *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET) = new_block_ofs;
+  *(uint64_t*)(index_p + INDEX_ENTRY_RESERVED_OFFSET) = 0;
 
   auto valid_counter = (uint32_t*)(block_p + 8);
 
@@ -827,6 +937,8 @@ void nanots_writer::write(write_context& wctx,
 #endif
 
   wctx.last_timestamp = timestamp;
+  if (secondary_key != NANOTS_SEC_KEY_UNSET)
+    wctx.last_secondary_key = secondary_key;
 }
 
 void nanots_writer::free_blocks(const std::string& file_name,
@@ -868,7 +980,6 @@ void nanots_writer::allocate_growable(const std::string& file_name,
                                       uint32_t block_size,
                                       uint32_t max_blocks) {
   // Growable mode is signalled by n_blocks == 0 in the file header.
-  // The optional max_blocks cap is stored at offset 8.
   allocate(file_name, block_size, 0);
 
   if (max_blocks > 0) {
@@ -878,8 +989,8 @@ void nanots_writer::allocate_growable(const std::string& file_name,
         nts_memory_map::NMM_PROT_READ | nts_memory_map::NMM_PROT_WRITE,
         nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED);
     uint8_t* p = (uint8_t*)mm.map();
-    *(uint32_t*)(p + 8) = max_blocks;
-    mm.flush(mm.map(), 12);
+    *(uint32_t*)(p + FILE_HEADER_MAX_BLOCKS_OFFSET) = max_blocks;
+    mm.flush(mm.map(), FILE_HEADER_USED_BYTES);
   }
 }
 
@@ -912,16 +1023,19 @@ void nanots_writer::allocate(const std::string& file_name,
 
     uint8_t* p = (uint8_t*)mm.map();
 
-    // write a file header
-    *(uint32_t*)p = block_size;
-    p += sizeof(uint32_t);
-    *(uint32_t*)p = n_blocks;
-    p += sizeof(uint32_t);
-    // offset 8: max_blocks cap for growable mode (0 = unbounded). Always
-    // zero here; allocate_growable() overwrites it if a cap was requested.
-    *(uint32_t*)p = 0;
+    // Write the v2 file header. Zero the first 64 bytes first so we have a
+    // clean slate (fallocate / SetEndOfFile leave indeterminate bytes here).
+    memset(p, 0, 64);
+    memcpy(p + FILE_HEADER_MAGIC_OFFSET, NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN);
+    *(uint16_t*)(p + FILE_HEADER_VERSION_OFFSET) = (uint16_t)NANOTS_FORMAT_VERSION;
+    *(uint16_t*)(p + FILE_HEADER_HSIZE_OFFSET)   = (uint16_t)FILE_HEADER_USED_BYTES;
+    *(uint32_t*)(p + FILE_HEADER_BLOCK_SIZE_OFFSET) = block_size;
+    *(uint32_t*)(p + FILE_HEADER_N_BLOCKS_OFFSET)   = n_blocks;
+    *(uint32_t*)(p + FILE_HEADER_MAX_BLOCKS_OFFSET) = 0;
+    *(uint32_t*)(p + FILE_HEADER_FLAGS_OFFSET)      = 0;
+    *(uint64_t*)(p + FILE_HEADER_FEATURES_OFFSET)   = 0;
 
-    mm.flush(mm.map(), 12);
+    mm.flush(mm.map(), 64);
   }
 
   auto db_name = _database_name(file_name);
@@ -944,7 +1058,8 @@ void nanots_writer::allocate(const std::string& file_name,
       "CREATE TABLE segments ("
       "id INTEGER PRIMARY KEY AUTOINCREMENT, "
       "stream_tag STRING, "
-      "metadata STRING "
+      "metadata STRING, "
+      "has_secondary_key INTEGER NOT NULL DEFAULT 0"
       ");";
   db.exec(query);
 
@@ -957,6 +1072,8 @@ void nanots_writer::allocate(const std::string& file_name,
       "block_idx INTEGER, "
       "start_timestamp INTEGER, "
       "end_timestamp INTEGER, "
+      "start_secondary_key INTEGER, "
+      "end_secondary_key INTEGER, "
       "uuid STRING, "
       "FOREIGN KEY (segment_id) REFERENCES segments(id)"
       ");";
@@ -982,6 +1099,11 @@ void nanots_writer::allocate(const std::string& file_name,
 
   query =
       "CREATE INDEX idx_segment_blocks_time_range ON segment_blocks(start_timestamp);";
+  db.exec(query);
+
+  query =
+      "CREATE INDEX idx_segment_blocks_sec_key ON "
+      "segment_blocks(segment_id, start_secondary_key);";
   db.exec(query);
 
   query = "CREATE INDEX idx_segments_stream_tag ON segments(stream_tag);";
@@ -1014,14 +1136,24 @@ nanots_reader::nanots_reader(const std::string& file_name)
 
   auto header_p = (uint8_t*)mm.map();
 
-  _block_size = *(uint32_t*)header_p;
+  if (memcmp(header_p + FILE_HEADER_MAGIC_OFFSET,
+             NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN) != 0)
+    throw nanots_exception(NANOTS_EC_BAD_MAGIC,
+                           "Not a nanots v2 file (bad magic).",
+                           __FILE__, __LINE__);
+  uint16_t version = *(uint16_t*)(header_p + FILE_HEADER_VERSION_OFFSET);
+  if (version != NANOTS_FORMAT_VERSION)
+    throw nanots_exception(NANOTS_EC_BAD_VERSION,
+                           "Unsupported nanots format version.",
+                           __FILE__, __LINE__);
 
-  _n_blocks = (*(uint32_t*)(header_p + sizeof(uint32_t)));
+  _block_size = *(uint32_t*)(header_p + FILE_HEADER_BLOCK_SIZE_OFFSET);
+  _n_blocks   = *(uint32_t*)(header_p + FILE_HEADER_N_BLOCKS_OFFSET);
 }
 
 static int _compare_index_entry_timestamp(uint8_t* index_entry_p,
                                           uint8_t* target_timestamp_p) {
-  int64_t entry_timestamp = *(int64_t*)index_entry_p;
+  int64_t entry_timestamp = *(int64_t*)(index_entry_p + INDEX_ENTRY_TS_OFFSET);
   int64_t target_timestamp = *(int64_t*)target_timestamp_p;
 
   if (entry_timestamp < target_timestamp)
@@ -1031,12 +1163,24 @@ static int _compare_index_entry_timestamp(uint8_t* index_entry_p,
   return 0;
 }
 
+static int _compare_index_entry_secondary_key(uint8_t* index_entry_p,
+                                              uint8_t* target_sk_p) {
+  int64_t entry_sk = *(int64_t*)(index_entry_p + INDEX_ENTRY_SECKEY_OFFSET);
+  int64_t target_sk = *(int64_t*)target_sk_p;
+
+  if (entry_sk < target_sk)
+    return -1;
+  if (entry_sk > target_sk)
+    return 1;
+  return 0;
+}
+
 void nanots_reader::read(
     const std::string& stream_tag,
     int64_t start_timestamp,
     int64_t end_timestamp,
     const std::function<
-        void(const uint8_t*, size_t, uint8_t, int64_t, int64_t, const std::string&)>& callback) {
+        void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback) {
   // EBR critical section spans the entire read(): the writer must not
   // overwrite any block whose bytes the callback might dereference.
   nanots_op_scope _op(_slot_guard);
@@ -1104,25 +1248,26 @@ void nanots_reader::read(
     // Iterate through frames in this block
     for (size_t i = start_index; i < n_valid_indexes; i++) {
       uint8_t* index_p = block_p + BLOCK_HEADER_SIZE + (i * INDEX_ENTRY_SIZE);
-      int64_t timestamp = *(int64_t*)index_p;
-      uint64_t offset = *(uint64_t*)(index_p + 8);
+      int64_t timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+      uint64_t offset   = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
       // Check if we've passed the end time
       if (timestamp > end_timestamp)
         return;  // All done!
 
       // Validate frame header
-      uint8_t flags;
+      uint32_t flags;
       uint32_t frame_size;
+      int64_t sec_key;
       if (!_validate_frame_header(block_p + offset, uuid, &flags,
-                                  &frame_size)) {
+                                  &frame_size, &sec_key)) {
         // Log warning? Skip corrupted frame
         continue;
       }
 
       // Callback with frame data
       callback(block_p + offset + FRAME_HEADER_SIZE, (size_t)frame_size, flags,
-               timestamp, block_sequence, metadata);
+               timestamp, sec_key, block_sequence, metadata);
     }
   }
 }
@@ -1221,16 +1366,43 @@ nanots_iterator::nanots_iterator(const std::string& file_name,
       _valid(false),
       _initialized(false),
       _slot_guard(nanots_epoch_registry::get_or_create(file_name)) {
-  // Read block size from file header
+  // Read block size + validate magic/version from file header.
   auto header_mm = nts_memory_map(
       filenum(_file), 0, FILE_HEADER_BLOCK_SIZE, nts_memory_map::NMM_PROT_READ,
       nts_memory_map::NMM_TYPE_FILE | nts_memory_map::NMM_SHARED);
 
   auto header_p = (uint8_t*)header_mm.map();
-  _block_size = *(uint32_t*)header_p;
+
+  if (memcmp(header_p + FILE_HEADER_MAGIC_OFFSET,
+             NANOTS_FILE_MAGIC, NANOTS_FILE_MAGIC_LEN) != 0)
+    throw nanots_exception(NANOTS_EC_BAD_MAGIC,
+                           "Not a nanots v2 file (bad magic).",
+                           __FILE__, __LINE__);
+  uint16_t version = *(uint16_t*)(header_p + FILE_HEADER_VERSION_OFFSET);
+  if (version != NANOTS_FORMAT_VERSION)
+    throw nanots_exception(NANOTS_EC_BAD_VERSION,
+                           "Unsupported nanots format version.",
+                           __FILE__, __LINE__);
+
+  _block_size = *(uint32_t*)(header_p + FILE_HEADER_BLOCK_SIZE_OFFSET);
 
   // Initialize to first frame if stream exists
   reset();
+}
+
+bool nanots_iterator::has_secondary_key() {
+  if (_has_secondary_key_cache >= 0) return _has_secondary_key_cache != 0;
+  auto& db = _ensure_db_connection();
+  auto stmt = db.prepare(
+      "SELECT has_secondary_key FROM segments WHERE stream_tag = ? LIMIT 1");
+  auto rows = stmt.bind(1, _stream_tag).exec();
+  int v = 0;
+  if (!rows.empty()) {
+    auto& cell = rows.front()["has_secondary_key"];
+    if (cell.has_value()) v = std::stoi(cell.value());
+  }
+  _has_secondary_key_cache = v;
+  return v != 0;
 }
 
 nts_sqlite_conn& nanots_iterator::_ensure_db_connection() {
@@ -1253,11 +1425,14 @@ block_info* nanots_iterator::_get_block_by_segment_and_sequence(int64_t segment_
     _stmt_get_block_by_id.emplace(_ensure_db_connection().prepare(
         "SELECT "
         "s.metadata as metadata, "
+        "s.has_secondary_key as has_secondary_key, "
         "sb.segment_id as segment_id, "
         "sb.sequence as block_sequence, "
         "sb.block_idx as block_idx, "
         "sb.start_timestamp as start_timestamp, "
         "sb.end_timestamp as end_timestamp, "
+        "sb.start_secondary_key as start_secondary_key, "
+        "sb.end_secondary_key as end_secondary_key, "
         "sb.uuid as uuid "
         "FROM segments s "
         "JOIN segment_blocks sb ON sb.segment_id = s.id "
@@ -1276,11 +1451,21 @@ block_info* nanots_iterator::_get_block_by_segment_and_sequence(int64_t segment_
   block.block_idx = std::stoll(row["block_idx"].value());
   block.block_sequence = std::stoll(row["block_sequence"].value());
   block.segment_id = std::stoll(row["segment_id"].value());
-  block.metadata = row["metadata"].value();
+  // Metadata may legitimately be the empty string, which the sqlite wrapper
+  // reports as a missing optional.
+  block.metadata = row["metadata"].has_value() ? row["metadata"].value() : std::string();
   block.uuid_hex = row["uuid"].value();
   block.start_timestamp = std::stoll(row["start_timestamp"].value());
   block.end_timestamp = std::stoll(row["end_timestamp"].value());
-  
+  auto& hsk = row["has_secondary_key"];
+  block.has_secondary_key = hsk.has_value() && std::stoi(hsk.value()) != 0;
+  auto& sk_start = row["start_secondary_key"];
+  block.start_secondary_key = sk_start.has_value()
+      ? std::stoll(sk_start.value()) : NANOTS_SEC_KEY_UNSET;
+  auto& sk_end = row["end_secondary_key"];
+  block.end_secondary_key = sk_end.has_value()
+      ? std::stoll(sk_end.value()) : NANOTS_SEC_KEY_UNSET;
+
   auto result = _block_cache.emplace(cache_key, std::move(block));
   return &result.first->second;
 }
@@ -1301,7 +1486,8 @@ void nanots_iterator::_refresh_ts_index() {
   // already in start_ts order — no sort needed.
   auto stmt = db.prepare(
       "SELECT sb.segment_id, sb.sequence, "
-      "       sb.start_timestamp, sb.end_timestamp "
+      "       sb.start_timestamp, sb.end_timestamp, "
+      "       sb.start_secondary_key, sb.end_secondary_key "
       "FROM segments s "
       "JOIN segment_blocks sb ON sb.segment_id = s.id "
       "WHERE s.stream_tag = ? "
@@ -1316,9 +1502,32 @@ void nanots_iterator::_refresh_ts_index() {
     br.sequence   = std::stoll(row["sequence"].value());
     br.start_ts   = std::stoll(row["start_timestamp"].value());
     br.end_ts     = std::stoll(row["end_timestamp"].value());
+    auto& s_sk = row["start_secondary_key"];
+    auto& e_sk = row["end_secondary_key"];
+    br.start_sk = s_sk.has_value() ? std::stoll(s_sk.value())
+                                   : NANOTS_SEC_KEY_UNSET;
+    br.end_sk   = e_sk.has_value() ? std::stoll(e_sk.value())
+                                   : NANOTS_SEC_KEY_UNSET;
     _ts_index.push_back(br);
   }
   _ts_index_filled = true;
+}
+
+size_t nanots_iterator::_ts_index_find_by_sk(int64_t sk) const {
+  // Prefer a block that covers sk.
+  auto it = std::upper_bound(_ts_index.begin(), _ts_index.end(), sk,
+      [](int64_t k, const BlockRange& br) { return k < br.start_sk; });
+  if (it != _ts_index.begin()) {
+    auto prev = std::prev(it);
+    if (sk >= prev->start_sk &&
+        (prev->end_sk == 0 || sk <= prev->end_sk)) {
+      return static_cast<size_t>(std::distance(_ts_index.begin(), prev));
+    }
+  }
+  if (it != _ts_index.end()) {
+    return static_cast<size_t>(std::distance(_ts_index.begin(), it));
+  }
+  return _ts_index.size();
 }
 
 size_t nanots_iterator::_ts_index_find(int64_t ts) const {
@@ -1456,6 +1665,73 @@ block_info* nanots_iterator::_find_block_for_timestamp(int64_t timestamp) {
   return try_at(pos);
 }
 
+block_info* nanots_iterator::_find_block_for_secondary_key(int64_t sec_key) {
+  _ensure_ts_index();
+
+  auto try_at = [&](size_t pos) -> block_info* {
+    if (pos >= _ts_index.size()) return nullptr;
+    const auto& br = _ts_index[pos];
+    auto* b = _get_block_by_segment_and_sequence(br.segment_id, br.sequence);
+    if (b) _ts_index_pos = pos;
+    return b;
+  };
+
+  size_t pos = _ts_index_find_by_sk(sec_key);
+  if (auto* b = try_at(pos)) return b;
+
+  _refresh_ts_index();
+  pos = _ts_index_find_by_sk(sec_key);
+  return try_at(pos);
+}
+
+bool nanots_iterator::find_by_secondary_key(int64_t sec_key) {
+  nanots_op_scope _op(_slot_guard);
+
+  if (!has_secondary_key()) {
+    _valid = false;
+    return false;
+  }
+
+  block_info* block = _find_block_for_secondary_key(sec_key);
+  if (!block) {
+    _valid = false;
+    return false;
+  }
+
+  if (!_load_block_data(*block)) {
+    _valid = false;
+    return false;
+  }
+
+  _current_block_start_ts = block->start_timestamp;
+  _current_block_end_ts   = block->end_timestamp;
+  _current_segment_id     = block->segment_id;
+  _current_block_sequence = block->block_sequence;
+
+  uint8_t* index_start = block->block_p + BLOCK_HEADER_SIZE;
+  uint8_t* index_end   = index_start + (block->n_valid_indexes * INDEX_ENTRY_SIZE);
+
+  uint8_t* found_entry =
+      lower_bound_bytes(index_start, index_end, (uint8_t*)&sec_key,
+                        INDEX_ENTRY_SIZE,
+                        _compare_index_entry_secondary_key);
+
+  _current_frame_idx = (found_entry - index_start) / INDEX_ENTRY_SIZE;
+
+  if (_current_frame_idx >= block->n_valid_indexes) {
+    auto* next_block = _get_next_block();
+    if (!next_block) {
+      _valid = false;
+      return false;
+    }
+    _current_segment_id = next_block->segment_id;
+    _current_block_sequence = next_block->block_sequence;
+    _current_frame_idx = 0;
+  }
+
+  return _load_current_frame();
+}
+
 bool nanots_iterator::_load_block_data(block_info& block) {
   if (block.is_loaded)
     return true;
@@ -1504,14 +1780,15 @@ bool nanots_iterator::_load_current_frame() {
   // Get frame info from index
   uint8_t* index_p = block->block_p + BLOCK_HEADER_SIZE +
                      (_current_frame_idx * INDEX_ENTRY_SIZE);
-  int64_t timestamp = *(int64_t*)index_p;
-  uint64_t offset = *(uint64_t*)(index_p + 8);
+  int64_t timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+  uint64_t offset   = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
   // Validate frame header
-  uint8_t flags;
+  uint32_t flags;
   uint32_t frame_size;
+  int64_t sec_key;
   if (!_validate_frame_header(block->block_p + offset, block->uuid, &flags,
-                              &frame_size)) {
+                              &frame_size, &sec_key)) {
     _valid = false;
     return false;
   }
@@ -1521,6 +1798,7 @@ bool nanots_iterator::_load_current_frame() {
   _current_frame.size = frame_size;
   _current_frame.flags = flags;
   _current_frame.timestamp = timestamp;
+  _current_frame.secondary_key = sec_key;
   _current_frame.block_sequence = block->block_sequence;
 
   _valid = true;
@@ -1643,14 +1921,15 @@ bool nanots_iterator::find(int64_t timestamp) {
   // Get frame info from index
   uint8_t* index_p = block->block_p + BLOCK_HEADER_SIZE +
                      (_current_frame_idx * INDEX_ENTRY_SIZE);
-  int64_t found_timestamp = *(int64_t*)index_p;
-  uint64_t offset = *(uint64_t*)(index_p + 8);
+  int64_t found_timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+  uint64_t offset = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
   // Validate frame header
-  uint8_t flags;
+  uint32_t flags;
   uint32_t frame_size;
+  int64_t sec_key;
   if (!_validate_frame_header(block->block_p + offset, block->uuid, &flags,
-                              &frame_size)) {
+                              &frame_size, &sec_key)) {
     _valid = false;
     return false;
   }
@@ -1660,6 +1939,7 @@ bool nanots_iterator::find(int64_t timestamp) {
   _current_frame.size = frame_size;
   _current_frame.flags = flags;
   _current_frame.timestamp = found_timestamp;
+  _current_frame.secondary_key = sec_key;
   _current_frame.block_sequence = block->block_sequence;
 
   _valid = true;
@@ -1819,8 +2099,9 @@ nanots_ec_t nanots_writer_write(nanots_writer_t writer,
                                 nanots_write_context_t context,
                                 const uint8_t* data,
                                 size_t size,
+                                uint32_t flags,
                                 int64_t timestamp,
-                                uint8_t flags) {
+                                int64_t secondary_key) {
   if (!writer || !writer->writer) {
     return NANOTS_EC_INVALID_ARGUMENT;
   }
@@ -1829,7 +2110,8 @@ nanots_ec_t nanots_writer_write(nanots_writer_t writer,
   }
 
   try {
-    writer->writer->write(context->context, data, size, timestamp, flags);
+    writer->writer->write(context->context, data, size,
+                          flags, timestamp, secondary_key);
     return NANOTS_EC_OK;
   } catch (const nanots_exception& e) {
     return e.get_ec();
@@ -1904,9 +2186,10 @@ nanots_ec_t nanots_reader_read(nanots_reader_t reader,
   try {
     nanots_callback_context ctx{callback, user_data};
     reader->reader->read(std::string(stream_tag), start_timestamp, end_timestamp,
-                         [&ctx](const uint8_t* data, size_t size, uint8_t flags,
-                                int64_t timestamp, int64_t block_sequence, const std::string& metadata) {
-                           ctx.callback(data, size, flags, timestamp,
+                         [&ctx](const uint8_t* data, size_t size, uint32_t flags,
+                                int64_t timestamp, int64_t secondary_key,
+                                int64_t block_sequence, const std::string& metadata) {
+                           ctx.callback(data, size, flags, timestamp, secondary_key,
                                         block_sequence, metadata.c_str(), ctx.user_data);
                          });
     return NANOTS_EC_OK;
@@ -2057,6 +2340,7 @@ nanots_ec_t nanots_iterator_get_current_frame(
     frame_info->size = frame.size;
     frame_info->flags = frame.flags;
     frame_info->timestamp = frame.timestamp;
+    frame_info->secondary_key = frame.secondary_key;
     frame_info->block_sequence = frame.block_sequence;
     return NANOTS_EC_OK;
   } catch (const nanots_exception& e) {
@@ -2125,6 +2409,37 @@ nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
   } catch (...) {
     fprintf(stderr,"Exception in nanots_iterator_find\n");
     return NANOTS_EC_UNKNOWN;
+  }
+}
+
+nanots_ec_t nanots_iterator_find_by_secondary_key(nanots_iterator_t iterator,
+                                                  int64_t secondary_key) {
+  if (!iterator || !iterator->iterator) {
+    return NANOTS_EC_INVALID_ARGUMENT;
+  }
+
+  try {
+    bool found = iterator->iterator->find_by_secondary_key(secondary_key);
+    return found ? NANOTS_EC_OK : NANOTS_EC_INVALID_ARGUMENT;
+  } catch (const nanots_exception& e) {
+    return e.get_ec();
+  } catch (const std::exception& e) {
+    fprintf(stderr,"Exception in nanots_iterator_find_by_secondary_key: %s\n", e.what());
+    return NANOTS_EC_UNKNOWN;
+  } catch (...) {
+    fprintf(stderr,"Exception in nanots_iterator_find_by_secondary_key\n");
+    return NANOTS_EC_UNKNOWN;
+  }
+}
+
+int nanots_iterator_has_secondary_key(nanots_iterator_t iterator) {
+  if (!iterator || !iterator->iterator) {
+    return 0;
+  }
+  try {
+    return iterator->iterator->has_secondary_key() ? 1 : 0;
+  } catch (...) {
+    return 0;
   }
 }
 

--- a/nanots.cpp
+++ b/nanots.cpp
@@ -417,35 +417,18 @@ static std::optional<block> _db_get_free_block(const nts_sqlite_conn& conn) {
 //  which composes _db_get_free_block / _grow_blocks / _db_reclaim_oldest_used_block
 //  with the EBR limbo/ready machinery.)
 
-// Look up whether any existing segment for this stream tag uses the secondary
-// key. Returns nullopt if no segment exists yet for this stream (caller's
-// choice will become the canonical one), or the 0/1 value otherwise.
-static std::optional<int> _db_lookup_stream_has_secondary_key(
-    const nts_sqlite_conn& conn, const std::string& stream_tag) {
-  auto stmt = conn.prepare(
-      "SELECT has_secondary_key FROM segments WHERE stream_tag = ? LIMIT 1");
-  auto rows = stmt.bind(1, stream_tag).exec();
-  if (rows.empty()) return std::nullopt;
-  return std::stoi(rows.front()["has_secondary_key"].value());
-}
-
 static std::optional<segment> _db_create_segment(const nts_sqlite_conn& conn,
                                                  const std::string& stream_tag,
-                                                 const std::string& metadata,
-                                                 bool has_secondary_key) {
+                                                 const std::string& metadata) {
   auto stmt = conn.prepare(
-      "INSERT INTO segments (stream_tag, metadata, has_secondary_key) VALUES (?, ?, ?)");
-  stmt.bind(1, stream_tag)
-      .bind(2, metadata)
-      .bind(3, has_secondary_key ? 1 : 0)
-      .exec_no_result();
+      "INSERT INTO segments (stream_tag, metadata) VALUES (?, ?)");
+  stmt.bind(1, stream_tag).bind(2, metadata).exec_no_result();
 
   segment s;
   s.id = std::stoll(conn.last_insert_id());
   s.stream_tag = stream_tag;
   s.metadata = metadata;
   s.sequence = 0;
-  s.has_secondary_key = has_secondary_key;
   return s;
 }
 
@@ -785,55 +768,38 @@ void nanots_writer::write(write_context& wctx,
                           uint32_t flags,
                           int64_t timestamp,
                           int64_t secondary_key) {
-  if (wctx.last_timestamp && timestamp <= wctx.last_timestamp.value())
-    throw nanots_exception(NANOTS_EC_NON_MONOTONIC_TIMESTAMP, "Timestamp is not monotonic.", __FILE__, __LINE__);
+  // Composite (timestamp, secondary_key) must be strictly greater than the
+  // previous frame's composite. When the caller doesn't pass a sec_key, the
+  // default is NANOTS_SEC_KEY_UNSET (= INT64_MIN); for a stream that never
+  // passes one this degenerates to "timestamp must strictly increase."
+  if (wctx.last_timestamp) {
+    int64_t last_ts = wctx.last_timestamp.value();
+    int64_t last_sk = wctx.last_secondary_key.value_or(NANOTS_SEC_KEY_UNSET);
+    bool composite_greater =
+        (timestamp > last_ts) ||
+        (timestamp == last_ts && secondary_key > last_sk);
+    if (!composite_greater) {
+      throw nanots_exception(
+          NANOTS_EC_NON_MONOTONIC_TIMESTAMP,
+          "Composite (timestamp, secondary_key) is not strictly greater than "
+          "the previous frame's composite.",
+          __FILE__, __LINE__);
+    }
+  }
 
   if (size >
       _block_size - (FRAME_HEADER_SIZE + INDEX_ENTRY_SIZE + BLOCK_HEADER_SIZE))
     throw nanots_exception(NANOTS_EC_ROW_SIZE_TOO_BIG, "Frame size is too large. Use a much larger block size.", __FILE__, __LINE__);
 
-  // First write to this context: lazily create (or attach to) the segment
-  // row. The very first write to a brand-new stream tag fixes the choice of
-  // whether the stream stores a secondary key on every frame.
+  // First write to this context: lazily create the segment row.
   if (!wctx.current_segment) {
-    bool wants_sec_key = (secondary_key != NANOTS_SEC_KEY_UNSET);
-
     nts_sqlite_conn conn(_database_name(_file_name), true, true);
     nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-      auto existing = _db_lookup_stream_has_secondary_key(conn, wctx.stream_tag);
-      if (existing.has_value()) {
-        bool existing_yes = (*existing != 0);
-        if (existing_yes != wants_sec_key) {
-          throw nanots_exception(
-              NANOTS_EC_SECONDARY_KEY_MISMATCH,
-              "Stream's secondary-key mode is fixed by its first write and "
-              "this write does not match.", __FILE__, __LINE__);
-        }
-      }
       wctx.current_segment = _db_create_segment(
-          conn, wctx.stream_tag, wctx.metadata, wants_sec_key);
+          conn, wctx.stream_tag, wctx.metadata);
       if (!wctx.current_segment)
         throw nanots_exception(NANOTS_EC_UNABLE_TO_CREATE_SEGMENT, "Unable to create segment.", __FILE__, __LINE__);
     });
-  } else {
-    // Subsequent writes: enforce the per-stream choice that was locked in
-    // on the first write.
-    bool stream_wants = wctx.current_segment->has_secondary_key;
-    bool this_write_provides = (secondary_key != NANOTS_SEC_KEY_UNSET);
-    if (stream_wants != this_write_provides) {
-      throw nanots_exception(
-          NANOTS_EC_SECONDARY_KEY_MISMATCH,
-          "Stream's secondary-key mode is fixed and this write does not match.",
-          __FILE__, __LINE__);
-    }
-  }
-
-  if (secondary_key != NANOTS_SEC_KEY_UNSET &&
-      wctx.last_secondary_key.has_value() &&
-      secondary_key <= wctx.last_secondary_key.value()) {
-    throw nanots_exception(NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY,
-                           "Secondary key is not monotonic.",
-                           __FILE__, __LINE__);
   }
 
   if (!wctx.current_block) {
@@ -937,8 +903,9 @@ void nanots_writer::write(write_context& wctx,
 #endif
 
   wctx.last_timestamp = timestamp;
-  if (secondary_key != NANOTS_SEC_KEY_UNSET)
-    wctx.last_secondary_key = secondary_key;
+  // Track the secondary key unconditionally so the composite monotonicity
+  // check on the next write has the right "last" value (including UNSET).
+  wctx.last_secondary_key = secondary_key;
 }
 
 void nanots_writer::free_blocks(const std::string& file_name,
@@ -1058,8 +1025,7 @@ void nanots_writer::allocate(const std::string& file_name,
       "CREATE TABLE segments ("
       "id INTEGER PRIMARY KEY AUTOINCREMENT, "
       "stream_tag STRING, "
-      "metadata STRING, "
-      "has_secondary_key INTEGER NOT NULL DEFAULT 0"
+      "metadata STRING"
       ");";
   db.exec(query);
 
@@ -1151,27 +1117,18 @@ nanots_reader::nanots_reader(const std::string& file_name)
   _n_blocks   = *(uint32_t*)(header_p + FILE_HEADER_N_BLOCKS_OFFSET);
 }
 
-static int _compare_index_entry_timestamp(uint8_t* index_entry_p,
-                                          uint8_t* target_timestamp_p) {
-  int64_t entry_timestamp = *(int64_t*)(index_entry_p + INDEX_ENTRY_TS_OFFSET);
-  int64_t target_timestamp = *(int64_t*)target_timestamp_p;
+// Lexicographic compare on (timestamp, secondary_key). Target is a 16-byte
+// buffer containing [target_ts (int64), target_sk (int64)]. Used for the
+// composite binary search inside a block.
+static int _compare_index_entry_composite(uint8_t* index_entry_p,
+                                          uint8_t* target_p) {
+  int64_t entry_ts = *(int64_t*)(index_entry_p + INDEX_ENTRY_TS_OFFSET);
+  int64_t target_ts = *(int64_t*)(target_p + 0);
+  if (entry_ts != target_ts) return entry_ts < target_ts ? -1 : 1;
 
-  if (entry_timestamp < target_timestamp)
-    return -1;
-  if (entry_timestamp > target_timestamp)
-    return 1;
-  return 0;
-}
-
-static int _compare_index_entry_secondary_key(uint8_t* index_entry_p,
-                                              uint8_t* target_sk_p) {
   int64_t entry_sk = *(int64_t*)(index_entry_p + INDEX_ENTRY_SECKEY_OFFSET);
-  int64_t target_sk = *(int64_t*)target_sk_p;
-
-  if (entry_sk < target_sk)
-    return -1;
-  if (entry_sk > target_sk)
-    return 1;
+  int64_t target_sk = *(int64_t*)(target_p + sizeof(int64_t));
+  if (entry_sk != target_sk) return entry_sk < target_sk ? -1 : 1;
   return 0;
 }
 
@@ -1237,9 +1194,12 @@ void nanots_reader::read(
     int64_t start_index = 0;
 
     if (need_binary_search) {
+      // Composite lower_bound at (start_timestamp, INT64_MIN) — i.e. the
+      // first frame at start_timestamp regardless of sec_key.
+      int64_t target[2] = {start_timestamp, NANOTS_SEC_KEY_UNSET};
       uint8_t* first_entry =
-          lower_bound_bytes(index_start, index_end, (uint8_t*)&start_timestamp,
-                            INDEX_ENTRY_SIZE, _compare_index_entry_timestamp);
+          lower_bound_bytes(index_start, index_end, (uint8_t*)target,
+                            INDEX_ENTRY_SIZE, _compare_index_entry_composite);
 
       start_index = (first_entry - index_start) / INDEX_ENTRY_SIZE;
       need_binary_search = false;
@@ -1390,21 +1350,6 @@ nanots_iterator::nanots_iterator(const std::string& file_name,
   reset();
 }
 
-bool nanots_iterator::has_secondary_key() {
-  if (_has_secondary_key_cache >= 0) return _has_secondary_key_cache != 0;
-  auto& db = _ensure_db_connection();
-  auto stmt = db.prepare(
-      "SELECT has_secondary_key FROM segments WHERE stream_tag = ? LIMIT 1");
-  auto rows = stmt.bind(1, _stream_tag).exec();
-  int v = 0;
-  if (!rows.empty()) {
-    auto& cell = rows.front()["has_secondary_key"];
-    if (cell.has_value()) v = std::stoi(cell.value());
-  }
-  _has_secondary_key_cache = v;
-  return v != 0;
-}
-
 nts_sqlite_conn& nanots_iterator::_ensure_db_connection() {
   if (!_db_conn.has_value()) {
     auto db_name = _database_name(_file_name);
@@ -1425,7 +1370,6 @@ block_info* nanots_iterator::_get_block_by_segment_and_sequence(int64_t segment_
     _stmt_get_block_by_id.emplace(_ensure_db_connection().prepare(
         "SELECT "
         "s.metadata as metadata, "
-        "s.has_secondary_key as has_secondary_key, "
         "sb.segment_id as segment_id, "
         "sb.sequence as block_sequence, "
         "sb.block_idx as block_idx, "
@@ -1457,8 +1401,6 @@ block_info* nanots_iterator::_get_block_by_segment_and_sequence(int64_t segment_
   block.uuid_hex = row["uuid"].value();
   block.start_timestamp = std::stoll(row["start_timestamp"].value());
   block.end_timestamp = std::stoll(row["end_timestamp"].value());
-  auto& hsk = row["has_secondary_key"];
-  block.has_secondary_key = hsk.has_value() && std::stoi(hsk.value()) != 0;
   auto& sk_start = row["start_secondary_key"];
   block.start_secondary_key = sk_start.has_value()
       ? std::stoll(sk_start.value()) : NANOTS_SEC_KEY_UNSET;
@@ -1513,35 +1455,37 @@ void nanots_iterator::_refresh_ts_index() {
   _ts_index_filled = true;
 }
 
-size_t nanots_iterator::_ts_index_find_by_sk(int64_t sk) const {
-  // Prefer a block that covers sk.
-  auto it = std::upper_bound(_ts_index.begin(), _ts_index.end(), sk,
-      [](int64_t k, const BlockRange& br) { return k < br.start_sk; });
-  if (it != _ts_index.begin()) {
-    auto prev = std::prev(it);
-    if (sk >= prev->start_sk &&
-        (prev->end_sk == 0 || sk <= prev->end_sk)) {
-      return static_cast<size_t>(std::distance(_ts_index.begin(), prev));
-    }
-  }
-  if (it != _ts_index.end()) {
-    return static_cast<size_t>(std::distance(_ts_index.begin(), it));
-  }
-  return _ts_index.size();
-}
 
-size_t nanots_iterator::_ts_index_find(int64_t ts) const {
-  // Prefer a block that covers ts.
-  auto it = std::upper_bound(_ts_index.begin(), _ts_index.end(), ts,
-      [](int64_t t, const BlockRange& br) { return t < br.start_ts; });
+size_t nanots_iterator::_ts_index_find(int64_t ts, int64_t sk) const {
+  // Composite-key search across blocks. Each block holds a sorted run of
+  // (ts, sk) tuples; the block's lex range is [(start_ts, start_sk),
+  // (end_ts, end_sk)]. We want the block whose range covers the target
+  // composite, or — failing that — the first block whose start composite
+  // is >= the target.
+  using P = std::pair<int64_t, int64_t>;
+  auto br_start = [](const BlockRange& br) { return P{br.start_ts, br.start_sk}; };
+  auto cmp_lt = [](P a, P b) {
+    return a.first != b.first ? a.first < b.first : a.second < b.second;
+  };
+
+  P target{ts, sk};
+  // First block whose start composite > target.
+  auto it = std::upper_bound(_ts_index.begin(), _ts_index.end(), target,
+      [&](P t, const BlockRange& br) { return cmp_lt(t, br_start(br)); });
+
   if (it != _ts_index.begin()) {
     auto prev = std::prev(it);
-    if (ts >= prev->start_ts &&
-        (prev->end_ts == 0 || ts <= prev->end_ts)) {
+    P prev_start = br_start(*prev);
+    bool ge_start = !cmp_lt(target, prev_start);  // target >= prev_start
+    bool open_block = (prev->end_ts == 0);
+    P prev_end{prev->end_ts, prev->end_sk};
+    bool le_end = open_block || !cmp_lt(prev_end, target);  // target <= prev_end
+    if (ge_start && le_end) {
       return static_cast<size_t>(std::distance(_ts_index.begin(), prev));
     }
   }
-  // Fallback: first block with start_ts >= ts (matches old SQL semantics).
+
+  // Fallback: first block whose start composite >= target.
   if (it != _ts_index.end()) {
     return static_cast<size_t>(std::distance(_ts_index.begin(), it));
   }
@@ -1639,7 +1583,8 @@ block_info* nanots_iterator::_get_prev_block() {
   return block;
 }
 
-block_info* nanots_iterator::_find_block_for_timestamp(int64_t timestamp) {
+block_info* nanots_iterator::_find_block_for_composite(int64_t timestamp,
+                                                       int64_t sec_key) {
   _ensure_ts_index();
 
   // Helper: given a position in _ts_index, look up its block_info. Returns
@@ -1653,7 +1598,7 @@ block_info* nanots_iterator::_find_block_for_timestamp(int64_t timestamp) {
   };
 
   // First attempt: snapshot we already have.
-  size_t pos = _ts_index_find(timestamp);
+  size_t pos = _ts_index_find(timestamp, sec_key);
   if (auto* b = try_at(pos)) return b;
 
   // Miss or stale: refresh and try once more. This catches:
@@ -1661,75 +1606,8 @@ block_info* nanots_iterator::_find_block_for_timestamp(int64_t timestamp) {
   //   (b) writer reclaimed the block we matched and the new (segment, sequence)
   //       at that idx isn't in our cache
   _refresh_ts_index();
-  pos = _ts_index_find(timestamp);
+  pos = _ts_index_find(timestamp, sec_key);
   return try_at(pos);
-}
-
-block_info* nanots_iterator::_find_block_for_secondary_key(int64_t sec_key) {
-  _ensure_ts_index();
-
-  auto try_at = [&](size_t pos) -> block_info* {
-    if (pos >= _ts_index.size()) return nullptr;
-    const auto& br = _ts_index[pos];
-    auto* b = _get_block_by_segment_and_sequence(br.segment_id, br.sequence);
-    if (b) _ts_index_pos = pos;
-    return b;
-  };
-
-  size_t pos = _ts_index_find_by_sk(sec_key);
-  if (auto* b = try_at(pos)) return b;
-
-  _refresh_ts_index();
-  pos = _ts_index_find_by_sk(sec_key);
-  return try_at(pos);
-}
-
-bool nanots_iterator::find_by_secondary_key(int64_t sec_key) {
-  nanots_op_scope _op(_slot_guard);
-
-  if (!has_secondary_key()) {
-    _valid = false;
-    return false;
-  }
-
-  block_info* block = _find_block_for_secondary_key(sec_key);
-  if (!block) {
-    _valid = false;
-    return false;
-  }
-
-  if (!_load_block_data(*block)) {
-    _valid = false;
-    return false;
-  }
-
-  _current_block_start_ts = block->start_timestamp;
-  _current_block_end_ts   = block->end_timestamp;
-  _current_segment_id     = block->segment_id;
-  _current_block_sequence = block->block_sequence;
-
-  uint8_t* index_start = block->block_p + BLOCK_HEADER_SIZE;
-  uint8_t* index_end   = index_start + (block->n_valid_indexes * INDEX_ENTRY_SIZE);
-
-  uint8_t* found_entry =
-      lower_bound_bytes(index_start, index_end, (uint8_t*)&sec_key,
-                        INDEX_ENTRY_SIZE,
-                        _compare_index_entry_secondary_key);
-
-  _current_frame_idx = (found_entry - index_start) / INDEX_ENTRY_SIZE;
-
-  if (_current_frame_idx >= block->n_valid_indexes) {
-    auto* next_block = _get_next_block();
-    if (!next_block) {
-      _valid = false;
-      return false;
-    }
-    _current_segment_id = next_block->segment_id;
-    _current_block_sequence = next_block->block_sequence;
-    _current_frame_idx = 0;
-  }
-
-  return _load_current_frame();
 }
 
 bool nanots_iterator::_load_block_data(block_info& block) {
@@ -1864,19 +1742,20 @@ nanots_iterator& nanots_iterator::operator--() {
   return *this;
 }
 
-bool nanots_iterator::find(int64_t timestamp) {
+bool nanots_iterator::find(int64_t timestamp, int64_t secondary_key) {
   nanots_op_scope _op(_slot_guard);
   block_info* block = nullptr;
 
-  // Fast path: if the target is within the already-loaded block's range, skip
-  // the SQL lookup entirely and go straight to the binary search.
+  // Fast path: if the target is within the already-loaded block's range
+  // (composite), skip the SQL lookup entirely.
   if (_valid && _current_block_end_ts != 0 &&
-      timestamp >= _current_block_start_ts && timestamp <= _current_block_end_ts) {
+      timestamp >= _current_block_start_ts &&
+      timestamp <= _current_block_end_ts) {
     block = _get_block_by_segment_and_sequence(_current_segment_id, _current_block_sequence);
   }
 
   if (!block)
-    block = _find_block_for_timestamp(timestamp);
+    block = _find_block_for_composite(timestamp, secondary_key);
 
   if (!block) {
     _valid = false;
@@ -1894,14 +1773,15 @@ bool nanots_iterator::find(int64_t timestamp) {
   _current_segment_id = block->segment_id;
   _current_block_sequence = block->block_sequence;
 
-  // Binary search within the block
+  // Composite lower_bound within the block.
   uint8_t* index_start = block->block_p + BLOCK_HEADER_SIZE;
   uint8_t* index_end =
       index_start + (block->n_valid_indexes * INDEX_ENTRY_SIZE);
 
+  int64_t target[2] = {timestamp, secondary_key};
   uint8_t* found_entry =
-      lower_bound_bytes(index_start, index_end, (uint8_t*)&timestamp,
-                        INDEX_ENTRY_SIZE, _compare_index_entry_timestamp);
+      lower_bound_bytes(index_start, index_end, (uint8_t*)target,
+                        INDEX_ENTRY_SIZE, _compare_index_entry_composite);
 
   _current_frame_idx = (found_entry - index_start) / INDEX_ENTRY_SIZE;
 
@@ -1918,32 +1798,7 @@ bool nanots_iterator::find(int64_t timestamp) {
     _current_frame_idx = 0;
   }
 
-  // Get frame info from index
-  uint8_t* index_p = block->block_p + BLOCK_HEADER_SIZE +
-                     (_current_frame_idx * INDEX_ENTRY_SIZE);
-  int64_t found_timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
-  uint64_t offset = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
-
-  // Validate frame header
-  uint32_t flags;
-  uint32_t frame_size;
-  int64_t sec_key;
-  if (!_validate_frame_header(block->block_p + offset, block->uuid, &flags,
-                              &frame_size, &sec_key)) {
-    _valid = false;
-    return false;
-  }
-
-  // Set up current frame
-  _current_frame.data = block->block_p + offset + FRAME_HEADER_SIZE;
-  _current_frame.size = frame_size;
-  _current_frame.flags = flags;
-  _current_frame.timestamp = found_timestamp;
-  _current_frame.secondary_key = sec_key;
-  _current_frame.block_sequence = block->block_sequence;
-
-  _valid = true;
-  return true;
+  return _load_current_frame();
 }
 
 void nanots_iterator::reset() {
@@ -2393,13 +2248,14 @@ nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator) {
 }
 
 nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
-                                     int64_t timestamp) {
+                                 int64_t timestamp,
+                                 int64_t secondary_key) {
   if (!iterator || !iterator->iterator) {
     return NANOTS_EC_INVALID_ARGUMENT;
   }
 
   try {
-    bool found = iterator->iterator->find(timestamp);
+    bool found = iterator->iterator->find(timestamp, secondary_key);
     return found ? NANOTS_EC_OK : NANOTS_EC_INVALID_ARGUMENT;
   } catch (const nanots_exception& e) {
     return e.get_ec();
@@ -2409,37 +2265,6 @@ nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
   } catch (...) {
     fprintf(stderr,"Exception in nanots_iterator_find\n");
     return NANOTS_EC_UNKNOWN;
-  }
-}
-
-nanots_ec_t nanots_iterator_find_by_secondary_key(nanots_iterator_t iterator,
-                                                  int64_t secondary_key) {
-  if (!iterator || !iterator->iterator) {
-    return NANOTS_EC_INVALID_ARGUMENT;
-  }
-
-  try {
-    bool found = iterator->iterator->find_by_secondary_key(secondary_key);
-    return found ? NANOTS_EC_OK : NANOTS_EC_INVALID_ARGUMENT;
-  } catch (const nanots_exception& e) {
-    return e.get_ec();
-  } catch (const std::exception& e) {
-    fprintf(stderr,"Exception in nanots_iterator_find_by_secondary_key: %s\n", e.what());
-    return NANOTS_EC_UNKNOWN;
-  } catch (...) {
-    fprintf(stderr,"Exception in nanots_iterator_find_by_secondary_key\n");
-    return NANOTS_EC_UNKNOWN;
-  }
-}
-
-int nanots_iterator_has_secondary_key(nanots_iterator_t iterator) {
-  if (!iterator || !iterator->iterator) {
-    return 0;
-  }
-  try {
-    return iterator->iterator->has_secondary_key() ? 1 : 0;
-  } catch (...) {
-    return 0;
   }
 }
 

--- a/nanots.cpp
+++ b/nanots.cpp
@@ -911,22 +911,35 @@ void nanots_writer::write(write_context& wctx,
 void nanots_writer::free_blocks(const std::string& file_name,
                                 const std::string& stream_tag,
                                 int64_t start_timestamp,
-                                int64_t end_timestamp) {
+                                int64_t start_secondary_key,
+                                int64_t end_timestamp,
+                                int64_t end_secondary_key) {
   auto db_name = _database_name(file_name);
   nts_sqlite_conn conn(db_name, true, true);
 
   nts_sqlite_transaction(conn, true, [&](const nts_sqlite_conn& conn) {
-    // Find blocks that fall entirely within the deletion time range
+    // Find blocks fully contained in the composite window
+    // [(start_ts, start_sk), (end_ts, end_sk)]:
+    //   block_start >= window_start:
+    //     start_ts > ? OR (start_ts = ? AND start_sk >= ?)
+    //   block_end <= window_end:
+    //     end_ts < ? OR (end_ts = ? AND end_sk <= ?)
+    // Plus end_timestamp != 0 to skip the currently-open block.
     auto stmt = conn.prepare(
         "SELECT sb.id as segment_block_id, sb.block_id "
         "FROM segment_blocks sb "
         "JOIN segments s ON sb.segment_id = s.id "
         "WHERE s.stream_tag = ? "
-        "AND sb.start_timestamp >= ? "
-        "AND sb.end_timestamp <= ? "
+        "AND (sb.start_timestamp > ? OR "
+        "     (sb.start_timestamp = ? AND sb.start_secondary_key >= ?)) "
+        "AND (sb.end_timestamp < ? OR "
+        "     (sb.end_timestamp = ? AND sb.end_secondary_key <= ?)) "
         "AND sb.end_timestamp != 0");
     auto blocks_to_delete =
-        stmt.bind(1, stream_tag).bind(2, start_timestamp).bind(3, end_timestamp).exec();
+        stmt.bind(1, stream_tag)
+            .bind(2, start_timestamp).bind(3, start_timestamp).bind(4, start_secondary_key)
+            .bind(5, end_timestamp).bind(6, end_timestamp).bind(7, end_secondary_key)
+            .exec();
 
     for (auto& block_row : blocks_to_delete) {
       int64_t segment_block_id = std::stoll(block_row["segment_block_id"].value());
@@ -1135,7 +1148,9 @@ static int _compare_index_entry_composite(uint8_t* index_entry_p,
 void nanots_reader::read(
     const std::string& stream_tag,
     int64_t start_timestamp,
+    int64_t start_secondary_key,
     int64_t end_timestamp,
+    int64_t end_secondary_key,
     const std::function<
         void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback) {
   // EBR critical section spans the entire read(): the writer must not
@@ -1144,6 +1159,13 @@ void nanots_reader::read(
 
   nts_sqlite_conn db(_database_name(_file_name), false, true);
 
+  // Composite overlap: include a block whose lex range
+  // [(start_ts, start_sk), (end_ts, end_sk)] intersects the requested
+  // window. Two lex comparisons:
+  //   block_start <= window_end:
+  //     start_ts < ?  OR  (start_ts = ? AND start_sk <= ?)
+  //   block_end >= window_start  (or open block end_ts == 0):
+  //     end_ts = 0 OR end_ts > ? OR (end_ts = ? AND end_sk >= ?)
   auto stmt = db.prepare(
       "SELECT "
       "s.metadata as metadata, "
@@ -1155,11 +1177,16 @@ void nanots_reader::read(
       "FROM segments s "
       "JOIN segment_blocks sb ON sb.segment_id = s.id "
       "WHERE s.stream_tag = ? "
-      "AND sb.start_timestamp <= ? "
-      "AND (sb.end_timestamp >= ? OR sb.end_timestamp = 0) "
+      "AND (sb.start_timestamp < ? OR "
+      "     (sb.start_timestamp = ? AND sb.start_secondary_key <= ?)) "
+      "AND (sb.end_timestamp = 0 OR sb.end_timestamp > ? OR "
+      "     (sb.end_timestamp = ? AND sb.end_secondary_key >= ?)) "
       "ORDER BY sb.sequence ASC;");
   auto results =
-      stmt.bind(1, stream_tag).bind(2, end_timestamp).bind(3, start_timestamp).exec();
+      stmt.bind(1, stream_tag)
+          .bind(2, end_timestamp).bind(3, end_timestamp).bind(4, end_secondary_key)
+          .bind(5, start_timestamp).bind(6, start_timestamp).bind(7, start_secondary_key)
+          .exec();
 
   bool need_binary_search = true;
 
@@ -1194,9 +1221,8 @@ void nanots_reader::read(
     int64_t start_index = 0;
 
     if (need_binary_search) {
-      // Composite lower_bound at (start_timestamp, INT64_MIN) — i.e. the
-      // first frame at start_timestamp regardless of sec_key.
-      int64_t target[2] = {start_timestamp, NANOTS_SEC_KEY_UNSET};
+      // Composite lower_bound at (start_timestamp, start_secondary_key).
+      int64_t target[2] = {start_timestamp, start_secondary_key};
       uint8_t* first_entry =
           lower_bound_bytes(index_start, index_end, (uint8_t*)target,
                             INDEX_ENTRY_SIZE, _compare_index_entry_composite);
@@ -1209,10 +1235,12 @@ void nanots_reader::read(
     for (size_t i = start_index; i < n_valid_indexes; i++) {
       uint8_t* index_p = block_p + BLOCK_HEADER_SIZE + (i * INDEX_ENTRY_SIZE);
       int64_t timestamp = *(int64_t*)(index_p + INDEX_ENTRY_TS_OFFSET);
+      int64_t sk_index  = *(int64_t*)(index_p + INDEX_ENTRY_SECKEY_OFFSET);
       uint64_t offset   = *(uint64_t*)(index_p + INDEX_ENTRY_OFFSET_OFFSET);
 
-      // Check if we've passed the end time
-      if (timestamp > end_timestamp)
+      // Check if we've passed the end composite.
+      if (timestamp > end_timestamp ||
+          (timestamp == end_timestamp && sk_index > end_secondary_key))
         return;  // All done!
 
       // Validate frame header
@@ -1232,16 +1260,27 @@ void nanots_reader::read(
   }
 }
 
-std::vector<std::string> nanots_reader::query_stream_tags(int64_t start_timestamp, int64_t end_timestamp) {
+std::vector<std::string> nanots_reader::query_stream_tags(
+    int64_t start_timestamp,
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key) {
   nts_sqlite_conn db(_database_name(_file_name), false, true);
 
+  // Composite overlap: a block contributes if its lex range overlaps the
+  // requested window. Same predicate as nanots_reader::read.
   auto stmt = db.prepare(
       "SELECT DISTINCT s.stream_tag "
       "FROM segments s "
       "JOIN segment_blocks sb ON s.id = sb.segment_id "
-      "WHERE sb.start_timestamp <= ? AND (sb.end_timestamp >= ? OR sb.end_timestamp = 0);");
+      "WHERE (sb.start_timestamp < ? OR "
+      "       (sb.start_timestamp = ? AND sb.start_secondary_key <= ?)) "
+      "AND (sb.end_timestamp = 0 OR sb.end_timestamp > ? OR "
+      "     (sb.end_timestamp = ? AND sb.end_secondary_key >= ?));");
   auto results =
-      stmt.bind(1, end_timestamp).bind(2, start_timestamp).exec();
+      stmt.bind(1, end_timestamp).bind(2, end_timestamp).bind(3, end_secondary_key)
+          .bind(4, start_timestamp).bind(5, start_timestamp).bind(6, start_secondary_key)
+          .exec();
 
   std::vector<std::string> stream_tags;
 
@@ -1255,58 +1294,84 @@ std::vector<std::string> nanots_reader::query_stream_tags(int64_t start_timestam
 std::vector<contiguous_segment> nanots_reader::query_contiguous_segments(
     const std::string& stream_tag,
     int64_t start_timestamp,
-    int64_t end_timestamp) {
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key) {
   nts_sqlite_conn db(_database_name(_file_name), false, true);
 
-  // Create a grouping key by subtracting sequence from row number
-  // Contiguous sequences will have the same group_key
-
+  // Create a grouping key by subtracting sequence from row number; within
+  // a stream blocks are composite-monotonic, so contiguous-by-sequence is
+  // also contiguous-by-composite. For each group we want the first block's
+  // (start_ts, start_sk) and the last block's (end_ts, end_sk).
+  //
+  // Composite overlap predicate matches nanots_reader::read.
   auto stmt = db.prepare(
     "WITH contiguous_groups AS ( "
     "  SELECT "
     "    sb.segment_id, "
     "    sb.sequence, "
     "    sb.start_timestamp, "
+    "    sb.start_secondary_key, "
     "    sb.end_timestamp, "
+    "    sb.end_secondary_key, "
     "    ROW_NUMBER() OVER (PARTITION BY sb.segment_id ORDER BY sb.sequence) "
     "      - sb.sequence AS group_key "
     "  FROM segment_blocks sb "
     "  JOIN segments s ON sb.segment_id = s.id "
-    "  WHERE sb.start_timestamp <= ? "                    /* bind(1) = window_end    */
-    "    AND (sb.end_timestamp >= ? OR sb.end_timestamp = 0) " /* bind(2) = window_start */
-    "    AND s.stream_tag = ? "                           /* bind(3) = stream_tag    */
+    "  WHERE s.stream_tag = ? "                       /* bind(1) */
+    "    AND (sb.start_timestamp < ? OR "             /* bind(2,3,4) — end composite */
+    "         (sb.start_timestamp = ? AND sb.start_secondary_key <= ?)) "
+    "    AND (sb.end_timestamp = 0 OR sb.end_timestamp > ? OR "  /* bind(5,6,7) — start composite */
+    "         (sb.end_timestamp = ? AND sb.end_secondary_key >= ?)) "
     "), "
     "region_boundaries AS ( "
     "  SELECT "
     "    segment_id, "
     "    group_key, "
-    "    MIN(start_timestamp) AS region_start, "
-    "    CASE "
-    "      WHEN MIN(end_timestamp) = 0 THEN 0 "
-    "      ELSE MAX(end_timestamp) "
-    "    END AS region_end, "
-    "    COUNT(*) AS block_count "
+    "    FIRST_VALUE(start_timestamp) "
+    "      OVER w AS region_start_ts, "
+    "    FIRST_VALUE(start_secondary_key) "
+    "      OVER w AS region_start_sk, "
+    "    LAST_VALUE(end_timestamp) "
+    "      OVER w_full AS region_end_ts, "
+    "    LAST_VALUE(end_secondary_key) "
+    "      OVER w_full AS region_end_sk, "
+    "    COUNT(*) OVER (PARTITION BY segment_id, group_key) AS block_count "
     "  FROM contiguous_groups "
-    "  GROUP BY segment_id, group_key "
+    "  WINDOW "
+    "    w AS (PARTITION BY segment_id, group_key ORDER BY sequence), "
+    "    w_full AS (PARTITION BY segment_id, group_key ORDER BY sequence "
+    "               ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) "
     ") "
-    "SELECT "
+    "SELECT DISTINCT "
     "  segment_id, "
-    "  region_start, "
-    "  region_end, "
+    "  region_start_ts, "
+    "  region_start_sk, "
+    "  region_end_ts, "
+    "  region_end_sk, "
     "  block_count "
     "FROM region_boundaries "
-    "ORDER BY segment_id, region_start;"
+    "ORDER BY segment_id, region_start_ts;"
   );
   auto results =
-      stmt.bind(1, end_timestamp).bind(2, start_timestamp).bind(3, stream_tag).exec();
+      stmt.bind(1, stream_tag)
+          .bind(2, end_timestamp).bind(3, end_timestamp).bind(4, end_secondary_key)
+          .bind(5, start_timestamp).bind(6, start_timestamp).bind(7, start_secondary_key)
+          .exec();
 
   std::vector<contiguous_segment> segments;
 
   for (auto& row : results) {
     contiguous_segment segment;
     segment.segment_id = std::stoll(row["segment_id"].value());
-    segment.start_timestamp = std::stoll(row["region_start"].value());
-    segment.end_timestamp = std::stoll(row["region_end"].value());
+    segment.start_timestamp = std::stoll(row["region_start_ts"].value());
+    segment.end_timestamp = std::stoll(row["region_end_ts"].value());
+    auto& s_sk = row["region_start_sk"];
+    auto& e_sk = row["region_end_sk"];
+    segment.start_secondary_key = s_sk.has_value()
+        ? std::stoll(s_sk.value()) : NANOTS_SEC_KEY_UNSET;
+    segment.end_secondary_key = e_sk.has_value()
+        ? std::stoll(e_sk.value()) : NANOTS_SEC_KEY_UNSET;
     segments.push_back(segment);
   }
 
@@ -1982,13 +2047,17 @@ nanots_ec_t nanots_writer_write(nanots_writer_t writer,
 nanots_ec_t nanots_writer_free_blocks(const char* file_name,
                                           const char* stream_tag,
                                           int64_t start_timestamp,
-                                          int64_t end_timestamp) {
+                                          int64_t start_secondary_key,
+                                          int64_t end_timestamp,
+                                          int64_t end_secondary_key) {
   if (!file_name || !stream_tag) {
     return NANOTS_EC_INVALID_ARGUMENT;
   }
 
   try {
-    nanots_writer::free_blocks(std::string(file_name), std::string(stream_tag), start_timestamp, end_timestamp);
+    nanots_writer::free_blocks(std::string(file_name), std::string(stream_tag),
+                               start_timestamp, start_secondary_key,
+                               end_timestamp, end_secondary_key);
     return NANOTS_EC_OK;
   } catch (const nanots_exception& e) {
     return e.get_ec();
@@ -2028,7 +2097,9 @@ struct nanots_callback_context {
 nanots_ec_t nanots_reader_read(nanots_reader_t reader,
                                const char* stream_tag,
                                int64_t start_timestamp,
+                               int64_t start_secondary_key,
                                int64_t end_timestamp,
+                               int64_t end_secondary_key,
                                nanots_read_callback_t callback,
                                void* user_data) {
   if (!reader || !reader->reader) {
@@ -2040,7 +2111,9 @@ nanots_ec_t nanots_reader_read(nanots_reader_t reader,
 
   try {
     nanots_callback_context ctx{callback, user_data};
-    reader->reader->read(std::string(stream_tag), start_timestamp, end_timestamp,
+    reader->reader->read(std::string(stream_tag),
+                         start_timestamp, start_secondary_key,
+                         end_timestamp, end_secondary_key,
                          [&ctx](const uint8_t* data, size_t size, uint32_t flags,
                                 int64_t timestamp, int64_t secondary_key,
                                 int64_t block_sequence, const std::string& metadata) {
@@ -2063,7 +2136,9 @@ nanots_ec_t nanots_reader_query_contiguous_segments(
     nanots_reader_t reader,
     const char* stream_tag,
     int64_t start_timestamp,
+    int64_t start_secondary_key,
     int64_t end_timestamp,
+    int64_t end_secondary_key,
     nanots_contiguous_segment_t** segments,
     size_t* count) {
   if (!reader || !reader->reader) {
@@ -2075,7 +2150,9 @@ nanots_ec_t nanots_reader_query_contiguous_segments(
 
   try {
     auto cpp_segments = reader->reader->query_contiguous_segments(
-        std::string(stream_tag), start_timestamp, end_timestamp);
+        std::string(stream_tag),
+        start_timestamp, start_secondary_key,
+        end_timestamp, end_secondary_key);
 
     *count = cpp_segments.size();
     if (*count == 0) {
@@ -2092,7 +2169,9 @@ nanots_ec_t nanots_reader_query_contiguous_segments(
     for (size_t i = 0; i < *count; i++) {
       (*segments)[i].segment_id = cpp_segments[i].segment_id;
       (*segments)[i].start_timestamp = cpp_segments[i].start_timestamp;
+      (*segments)[i].start_secondary_key = cpp_segments[i].start_secondary_key;
       (*segments)[i].end_timestamp = cpp_segments[i].end_timestamp;
+      (*segments)[i].end_secondary_key = cpp_segments[i].end_secondary_key;
     }
 
     return NANOTS_EC_OK;
@@ -2113,13 +2192,17 @@ void nanots_free_contiguous_segments(nanots_contiguous_segment_t* segments) {
 
 nanots_ec_t nanots_reader_query_stream_tags_start(nanots_reader_t reader,
                                                   int64_t start_timestamp,
-                                                  int64_t end_timestamp) {
+                                                  int64_t start_secondary_key,
+                                                  int64_t end_timestamp,
+                                                  int64_t end_secondary_key) {
   if (!reader || !reader->reader) {
     return NANOTS_EC_INVALID_ARGUMENT;
   }
 
   try {
-    reader->cached_stream_tags = reader->reader->query_stream_tags(start_timestamp, end_timestamp);
+    reader->cached_stream_tags = reader->reader->query_stream_tags(
+        start_timestamp, start_secondary_key,
+        end_timestamp, end_secondary_key);
     reader->stream_tags_iterator = 0;
     return NANOTS_EC_OK;
   } catch (const nanots_exception& e) {

--- a/nanots.h
+++ b/nanots.h
@@ -335,11 +335,18 @@ class NANOTS_API nanots_writer {
         int64_t secondary_key = NANOTS_SEC_KEY_UNSET
     );
 
+    // Free every block in this stream that falls entirely within the
+    // composite window [(start_ts, start_sk), (end_ts, end_sk)]. Pass
+    // NANOTS_SEC_KEY_UNSET for start_secondary_key and INT64_MAX for
+    // end_secondary_key to ignore the sec_key axis (the classic
+    // timestamp-only deletion).
     static void free_blocks(
         const std::string& file_name,
         const std::string& stream_tag,
         int64_t start_timestamp,
-        int64_t end_timestamp
+        int64_t start_secondary_key,
+        int64_t end_timestamp,
+        int64_t end_secondary_key
     );
 
     // Preallocated: fixed-size file with n_blocks slots, never grows.
@@ -416,7 +423,9 @@ class NANOTS_API nanots_writer {
 struct contiguous_segment {
     int64_t segment_id{0};
     int64_t start_timestamp{0};
+    int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
     int64_t end_timestamp{0};
+    int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
 };
 
 class NANOTS_API nanots_reader {
@@ -428,6 +437,11 @@ class NANOTS_API nanots_reader {
     nanots_reader& operator=(nanots_reader&&) = default;
     ~nanots_reader() = default;
 
+    // Stream all frames whose composite (timestamp, secondary_key) falls
+    // within [(start_ts, start_sk), (end_ts, end_sk)] inclusive. Pass
+    // NANOTS_SEC_KEY_UNSET for start_secondary_key and INT64_MAX for
+    // end_secondary_key to ignore the sec_key axis.
+    //
     // Callback signature is:
     //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
     // `secondary_key` is NANOTS_SEC_KEY_UNSET for frames whose writer didn't
@@ -435,20 +449,32 @@ class NANOTS_API nanots_reader {
     void read(
         const std::string& stream_tag,
         int64_t start_timestamp,
+        int64_t start_secondary_key,
         int64_t end_timestamp,
+        int64_t end_secondary_key,
         const std::function<
             void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback
     );
 
+    // Distinct stream tags that have any block overlapping the composite
+    // window. Use NANOTS_SEC_KEY_UNSET / INT64_MAX for sec_key bounds to
+    // ignore that axis.
     std::vector<std::string> query_stream_tags(
         int64_t start_timestamp,
-        int64_t end_timestamp
+        int64_t start_secondary_key,
+        int64_t end_timestamp,
+        int64_t end_secondary_key
     );
 
+    // Contiguous runs of blocks for this stream within the composite window.
+    // Use NANOTS_SEC_KEY_UNSET / INT64_MAX for sec_key bounds to ignore
+    // that axis.
     std::vector<contiguous_segment> query_contiguous_segments(
         const std::string& stream_tag,
         int64_t start_timestamp,
-        int64_t end_timestamp
+        int64_t start_secondary_key,
+        int64_t end_timestamp,
+        int64_t end_secondary_key
     );
 
  private:
@@ -636,7 +662,9 @@ typedef struct nanots_iterator_handle* nanots_iterator_t;
 typedef struct {
   int64_t segment_id;
   int64_t start_timestamp;
+  int64_t start_secondary_key;
   int64_t end_timestamp;
+  int64_t end_secondary_key;
 } nanots_contiguous_segment_t;
 
 typedef struct {
@@ -688,11 +716,11 @@ NANOTS_API nanots_write_context_t nanots_writer_create_context(
 NANOTS_API void nanots_write_context_destroy(nanots_write_context_t context);
 
 // Pass NANOTS_SEC_KEY_UNSET (INT64_MIN) for `secondary_key` to write into
-// a stream without a secondary key. The first write to a stream fixes the
-// choice; mixing yields NANOTS_EC_SECONDARY_KEY_MISMATCH.
+// a stream that doesn't use a tiebreaker. Frames are ordered by the
+// composite (timestamp, secondary_key) which must be strictly monotonic.
 //
 // Argument order mirrors the C++ method: flags, then timestamp, then the
-// optional secondary key. The C ABI has no defaults — pass all 7 args.
+// secondary key. The C ABI has no defaults — pass all 7 args.
 NANOTS_API nanots_ec_t nanots_writer_write(
     nanots_writer_t writer,
     nanots_write_context_t context,
@@ -703,11 +731,16 @@ NANOTS_API nanots_ec_t nanots_writer_write(
     int64_t secondary_key
 );
 
+// Free blocks fully contained in the composite window
+// [(start_ts, start_sk), (end_ts, end_sk)]. Use NANOTS_SEC_KEY_UNSET and
+// INT64_MAX for the sec_key bounds to ignore that axis.
 NANOTS_API nanots_ec_t nanots_writer_free_blocks(
     const char* file_name,
     const char* stream_tag,
     int64_t start_timestamp,
-    int64_t end_timestamp
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key
 );
 
 // reader
@@ -715,11 +748,16 @@ NANOTS_API nanots_reader_t nanots_reader_create(const char* file_name);
 
 NANOTS_API void nanots_reader_destroy(nanots_reader_t reader);
 
+// Stream frames whose composite (timestamp, secondary_key) lies within
+// [(start_ts, start_sk), (end_ts, end_sk)]. Use NANOTS_SEC_KEY_UNSET and
+// INT64_MAX for the sec_key bounds to ignore that axis.
 NANOTS_API nanots_ec_t nanots_reader_read(
     nanots_reader_t reader,
     const char* stream_tag,
     int64_t start_timestamp,
+    int64_t start_secondary_key,
     int64_t end_timestamp,
+    int64_t end_secondary_key,
     nanots_read_callback_t callback,
     void* user_data
 );
@@ -728,7 +766,9 @@ NANOTS_API nanots_ec_t nanots_reader_query_contiguous_segments(
     nanots_reader_t reader,
     const char* stream_tag,
     int64_t start_timestamp,
+    int64_t start_secondary_key,
     int64_t end_timestamp,
+    int64_t end_secondary_key,
     nanots_contiguous_segment_t** segments,
     size_t* count
 );
@@ -738,7 +778,9 @@ NANOTS_API void nanots_free_contiguous_segments(nanots_contiguous_segment_t* seg
 NANOTS_API nanots_ec_t nanots_reader_query_stream_tags_start(
     nanots_reader_t reader,
     int64_t start_timestamp,
-    int64_t end_timestamp
+    int64_t start_secondary_key,
+    int64_t end_timestamp,
+    int64_t end_secondary_key
 );
 
 NANOTS_API const char* nanots_reader_query_stream_tags_next(nanots_reader_t reader);

--- a/nanots.h
+++ b/nanots.h
@@ -20,7 +20,11 @@ enum nanots_ec_t {
   NANOTS_EC_UNABLE_TO_ALLOCATE_FILE = 10,
   NANOTS_EC_INVALID_ARGUMENT = 11,
   NANOTS_EC_UNKNOWN = 12,
-  NANOTS_EC_NOT_FOUND = 13
+  NANOTS_EC_NOT_FOUND = 13,
+  NANOTS_EC_BAD_MAGIC = 14,
+  NANOTS_EC_BAD_VERSION = 15,
+  NANOTS_EC_SECONDARY_KEY_MISMATCH = 16,
+  NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY = 17
 };
 
 }
@@ -45,26 +49,79 @@ private:
   int _line;
 };
 
+// --- On-disk format version 2 -------------------------------------------
+// File magic: ASCII "NTS\0". Legacy v1 files had block_size (always a
+// multiple of 65536) at offset 0, which can never collide with this magic
+// in its low byte ('N' = 0x4E), so the sniff is unambiguous.
+#define NANOTS_FILE_MAGIC "NTS\0"
+#define NANOTS_FILE_MAGIC_LEN 4
+#define NANOTS_FORMAT_VERSION 2
+
 #define FILE_HEADER_BLOCK_SIZE 65536
-// 8 + 4 + 4 bytes (with padding)
+// File header field offsets (within the first 64 KB; rest is reserved):
+//   0  : magic[4]                = "NTS\0"
+//   4  : format_version (u16)    = 2
+//   6  : header_size    (u16)    = bytes actually used (>= 32)
+//   8  : block_size     (u32)
+//   12 : n_blocks       (u32; 0 = growable)
+//   16 : max_blocks     (u32; growable cap, 0 = unbounded)
+//   20 : flags          (u32; reserved, currently 0)
+//   24 : feature_bits   (u64; bit 0 = secondary_key bit reserved for future
+//                       per-file features. Per-stream secondary-key opt-in
+//                       is recorded in segments.has_secondary_key.)
+//   32 : reserved (zeroed)
+#define FILE_HEADER_MAGIC_OFFSET     0
+#define FILE_HEADER_VERSION_OFFSET   4
+#define FILE_HEADER_HSIZE_OFFSET     6
+#define FILE_HEADER_BLOCK_SIZE_OFFSET 8
+#define FILE_HEADER_N_BLOCKS_OFFSET  12
+#define FILE_HEADER_MAX_BLOCKS_OFFSET 16
+#define FILE_HEADER_FLAGS_OFFSET     20
+#define FILE_HEADER_FEATURES_OFFSET  24
+#define FILE_HEADER_USED_BYTES       32
+
+// 8 + 4 + 4 bytes. block_feature_bits (was 'reserved') is repurposed as
+// per-block feature flags for future use; currently always 0.
 #define BLOCK_HEADER_SIZE 16
-// 8 + 8 bytes
-#define INDEX_ENTRY_SIZE 16
-// 16 + 1 + 4 bytes
-#define FRAME_HEADER_SIZE 21
-#define FRAME_UUID_OFFSET 0
-#define FRAME_SIZE_OFFSET 16
-#define FRAME_FLAGS_OFFSET 20
+
+// v2 index entry: 8 + 8 + 8 + 8 = 32 bytes.
+//   0  : timestamp     (int64)
+//   8  : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the stream has none)
+//   16 : offset        (uint64; byte offset of frame in block)
+//   24 : reserved      (uint64; zeroed)
+#define INDEX_ENTRY_SIZE 32
+#define INDEX_ENTRY_TS_OFFSET      0
+#define INDEX_ENTRY_SECKEY_OFFSET  8
+#define INDEX_ENTRY_OFFSET_OFFSET 16
+#define INDEX_ENTRY_RESERVED_OFFSET 24
+
+// v2 frame header: 16 + 8 + 4 + 4 = 32 bytes (8-byte aligned, payload at +32).
+//   0  : uuid[16]
+//   16 : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the stream has none)
+//   24 : size          (uint32)
+//   28 : flags         (uint32 — widened from u8 in v2)
+#define FRAME_HEADER_SIZE 32
+#define FRAME_UUID_OFFSET        0
+#define FRAME_SECKEY_OFFSET     16
+#define FRAME_SIZE_OFFSET       24
+#define FRAME_FLAGS_OFFSET      28
+
+// Sentinel for "no secondary key on this frame". Streams either always have
+// one or never have one; the choice is fixed at the first write into the
+// stream and stored in segments.has_secondary_key.
+#define NANOTS_SEC_KEY_UNSET INT64_MIN
 
 struct block_header {
   int64_t block_start_timestamp{0};
   uint32_t n_valid_indexes{0};
-  uint32_t reserved{0};
+  uint32_t block_feature_bits{0};
 };
 
 struct index_entry {
-  int64_t timestamp;
-  uint32_t offset;
+  int64_t timestamp{0};
+  int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
+  uint64_t offset{0};
+  uint64_t reserved{0};
 };
 
 struct block {
@@ -77,6 +134,10 @@ struct segment {
   std::string stream_tag;
   std::string metadata;
   int64_t sequence{0};
+  // True if every write into this segment must include a secondary key.
+  // Locked at segment creation time and (for the stream as a whole) recorded
+  // on the first segment created for that stream tag — see _db_create_segment.
+  bool has_secondary_key{false};
 };
 
 struct segment_block {
@@ -87,6 +148,8 @@ struct segment_block {
   int64_t block_idx{0};
   int64_t start_timestamp{0};
   int64_t end_timestamp{0};
+  int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+  int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
   uint8_t uuid[16];
 };
 
@@ -227,6 +290,7 @@ struct NANOTS_API write_context final {
   std::string metadata;
   std::string stream_tag;
   std::optional<int64_t> last_timestamp;
+  std::optional<int64_t> last_secondary_key;
   std::optional<segment> current_segment;
   std::optional<segment_block> current_block;
   nts_file file;
@@ -247,11 +311,21 @@ class NANOTS_API nanots_writer {
   write_context create_write_context(const std::string& stream_tag,
                                      const std::string& metadata);
 
+  // `secondary_key` defaults to NANOTS_SEC_KEY_UNSET — pass any other int64
+  // to write into a *keyed* stream. The choice is fixed by the first write to
+  // a given stream tag; mixing keyed and unkeyed writes on the same stream is
+  // rejected with NANOTS_EC_SECONDARY_KEY_MISMATCH. Keys are strictly
+  // monotonic within a stream.
+  //
+  // Argument order: (timestamp, secondary_key) are grouped at the end as the
+  // frame's ordering keys, with flags before them so the unkeyed call shape
+  // is just write(wctx, data, size, flags, timestamp).
   void write(write_context& wctx,
              const uint8_t* data,
              size_t size,
+             uint32_t flags,
              int64_t timestamp,
-             uint8_t flags);
+             int64_t secondary_key = NANOTS_SEC_KEY_UNSET);
 
   static void free_blocks(const std::string& file_name,
                           const std::string& stream_tag,
@@ -340,12 +414,15 @@ class NANOTS_API nanots_reader {
   nanots_reader& operator=(nanots_reader&&) = default;
   ~nanots_reader() = default;
 
+  // Callback signature is:
+  //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
+  // `secondary_key` is NANOTS_SEC_KEY_UNSET for streams that don't use one.
   void read(
       const std::string& stream_tag,
       int64_t start_timestamp,
       int64_t end_timestamp,
       const std::function<
-          void(const uint8_t*, size_t, uint8_t, int64_t, int64_t, const std::string&)>& callback);
+          void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback);
   
   std::vector<std::string> query_stream_tags(int64_t start_timestamp, int64_t end_timestamp);
 
@@ -369,8 +446,9 @@ class NANOTS_API nanots_reader {
 struct frame_info {
   const uint8_t* data{nullptr};
   size_t size{0};
-  uint8_t flags{0};
+  uint32_t flags{0};
   int64_t timestamp{0};
+  int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
   int64_t block_sequence{0};
 };
 
@@ -382,6 +460,9 @@ struct block_info {
   std::string uuid_hex;
   int64_t start_timestamp{0};
   int64_t end_timestamp{0};
+  int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+  int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
+  bool has_secondary_key{false};
 
   // Loaded block data
   nts_memory_map mm;
@@ -409,12 +490,17 @@ class NANOTS_API nanots_iterator {
   nanots_iterator& operator++();  // Move to next frame
   nanots_iterator& operator--();  // Move to previous frame
   bool find(int64_t timestamp);  // Find first frame >= timestamp
+  // Find first frame with secondary_key >= sec_key. Only valid on streams
+  // whose has_secondary_key == true; returns false otherwise.
+  bool find_by_secondary_key(int64_t sec_key);
   bool seek_end();               // Go to last frame
   void reset();                   // Go to first frame
 
   // Utility
   int64_t current_block_sequence() const { return _current_block_sequence; }
   const std::string& current_metadata() const;
+  // True if this stream stores a secondary key on every frame.
+  bool has_secondary_key();
 
  private:
   // In-memory index of all blocks in this stream, sorted by start_ts
@@ -428,6 +514,8 @@ class NANOTS_API nanots_iterator {
     int64_t end_ts;       // 0 = open block (currently being written)
     int64_t segment_id;
     int64_t sequence;
+    int64_t start_sk;     // NANOTS_SEC_KEY_UNSET if stream has no sec key
+    int64_t end_sk;       // 0 boundary semantics same as end_ts
   };
 
   block_info* _get_block_by_segment_and_sequence(int64_t segment_id, int64_t sequence);
@@ -436,6 +524,7 @@ class NANOTS_API nanots_iterator {
   block_info* _get_next_block();
   block_info* _get_prev_block();
   block_info* _find_block_for_timestamp(int64_t timestamp);
+  block_info* _find_block_for_secondary_key(int64_t sec_key);
 
   // Build (or rebuild) the timestamp index from SQL. _ensure_ts_index is the
   // lazy entry point used by navigation methods.
@@ -447,6 +536,10 @@ class NANOTS_API nanots_iterator {
   // block that covers ts (start_ts <= ts <= end_ts, or end_ts == 0); otherwise
   // returns the first block with start_ts >= ts.
   size_t _ts_index_find(int64_t ts) const;
+
+  // Same as _ts_index_find but searches by secondary key. Only meaningful for
+  // streams whose has_secondary_key is true.
+  size_t _ts_index_find_by_sk(int64_t sk) const;
 
   // True if _ts_index_pos matches (current_segment_id, current_block_sequence).
   bool   _ts_index_pos_is_valid() const;
@@ -462,6 +555,9 @@ class NANOTS_API nanots_iterator {
   std::string _stream_tag;
   nts_file _file;
   uint32_t _block_size;
+  // Cached from the segments row for this stream. -1 = not yet known;
+  // 0 = no, 1 = yes.
+  int _has_secondary_key_cache{-1};
 
   // Current position
   int64_t _current_block_sequence;
@@ -526,15 +622,17 @@ typedef struct {
 typedef struct {
   const uint8_t* data;
   size_t size;
-  uint8_t flags;
+  uint32_t flags;
   int64_t timestamp;
+  int64_t secondary_key;
   int64_t block_sequence;
 } nanots_frame_info_t;
 
 typedef void (*nanots_read_callback_t)(const uint8_t* data,
                                        size_t size,
-                                       uint8_t flags,
+                                       uint32_t flags,
                                        int64_t timestamp,
+                                       int64_t secondary_key,
                                        int64_t block_sequence,
                                        const char* metadata,
                                        void* user_data);
@@ -554,12 +652,19 @@ NANOTS_API nanots_write_context_t nanots_writer_create_context(nanots_writer_t w
 
 NANOTS_API void nanots_write_context_destroy(nanots_write_context_t context);
 
+// Pass NANOTS_SEC_KEY_UNSET (INT64_MIN) for `secondary_key` to write into
+// a stream without a secondary key. The first write to a stream fixes the
+// choice; mixing yields NANOTS_EC_SECONDARY_KEY_MISMATCH.
+//
+// Argument order mirrors the C++ method: flags, then timestamp, then the
+// optional secondary key. The C ABI has no defaults — pass all 7 args.
 NANOTS_API nanots_ec_t nanots_writer_write(nanots_writer_t writer,
                                     nanots_write_context_t context,
                                     const uint8_t* data,
                                     size_t size,
+                                    uint32_t flags,
                                     int64_t timestamp,
-                                    uint8_t flags);
+                                    int64_t secondary_key);
 
 NANOTS_API nanots_ec_t nanots_writer_free_blocks(const char* file_name,
                                       const char* stream_tag,
@@ -611,6 +716,14 @@ NANOTS_API nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator);
 
 NANOTS_API nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
                                      int64_t timestamp);
+
+// Returns NANOTS_EC_INVALID_ARGUMENT if the stream has no secondary key.
+NANOTS_API nanots_ec_t nanots_iterator_find_by_secondary_key(
+    nanots_iterator_t iterator,
+    int64_t secondary_key);
+
+// 1 if this iterator's stream stores secondary keys, 0 otherwise.
+NANOTS_API int nanots_iterator_has_secondary_key(nanots_iterator_t iterator);
 
 NANOTS_API nanots_ec_t nanots_iterator_reset(nanots_iterator_t iterator);
 

--- a/nanots.h
+++ b/nanots.h
@@ -23,32 +23,33 @@ enum nanots_ec_t {
   NANOTS_EC_NOT_FOUND = 13,
   NANOTS_EC_BAD_MAGIC = 14,
   NANOTS_EC_BAD_VERSION = 15
-  // Reserved 16-17 (previously SECONDARY_KEY_MISMATCH and
-  // NON_MONOTONIC_SECONDARY_KEY). Composite-key semantics fold both into
-  // NANOTS_EC_NON_MONOTONIC_TIMESTAMP, which now means "composite (ts,
-  // sec_key) is not strictly greater than the previous frame's composite."
 };
 
 }
 
 class NANOTS_API nanots_exception : public std::exception {
 public:
-  nanots_exception(nanots_ec_t ec, const std::string& message, const std::string& file, int line) : _ec(ec), _message(message), _file(file), _line(line) {}
-  nanots_exception(const nanots_exception& other) = default;
-  nanots_exception& operator=(const nanots_exception& other) = default;
-  nanots_exception(nanots_exception&& other) noexcept = default;
-  nanots_exception& operator=(nanots_exception&& other) noexcept = default;
-  nanots_ec_t get_ec() const { return _ec; }
-  const char* what() const noexcept override {
-    _formatted_message = format_s("%s:%d: %d(%s)", _file.c_str(), _line, _ec, _message.c_str());
-    return _formatted_message.c_str();
-  }
+    nanots_exception(
+       nanots_ec_t ec,
+       const std::string& message,
+       const std::string& file,
+       int line
+    ) : _ec(ec), _message(message), _file(file), _line(line) {}
+    nanots_exception(const nanots_exception& other) = default;
+    nanots_exception& operator=(const nanots_exception& other) = default;
+    nanots_exception(nanots_exception&& other) noexcept = default;
+    nanots_exception& operator=(nanots_exception&& other) noexcept = default;
+    nanots_ec_t get_ec() const { return _ec; }
+    const char* what() const noexcept override {
+      _formatted_message = format_s("%s:%d: %d(%s)", _file.c_str(), _line, _ec, _message.c_str());
+      return _formatted_message.c_str();
+    }
 private:
-  nanots_ec_t _ec;
-  std::string _message;
-  mutable std::string _formatted_message;
-  std::string _file;
-  int _line;
+    nanots_ec_t _ec;
+    std::string _message;
+    mutable std::string _formatted_message;
+    std::string _file;
+    int _line;
 };
 
 // --- On-disk format version 2 -------------------------------------------
@@ -68,9 +69,8 @@ private:
 //   12 : n_blocks       (u32; 0 = growable)
 //   16 : max_blocks     (u32; growable cap, 0 = unbounded)
 //   20 : flags          (u32; reserved, currently 0)
-//   24 : feature_bits   (u64; bit 0 = secondary_key bit reserved for future
-//                       per-file features. Per-stream secondary-key opt-in
-//                       is recorded in segments.has_secondary_key.)
+//   24 : feature_bits   (u64; reserved for future per-file feature flags,
+//                       currently zero)
 //   32 : reserved (zeroed)
 #define FILE_HEADER_MAGIC_OFFSET     0
 #define FILE_HEADER_VERSION_OFFSET   4
@@ -88,7 +88,8 @@ private:
 
 // v2 index entry: 8 + 8 + 8 + 8 = 32 bytes.
 //   0  : timestamp     (int64)
-//   8  : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the stream has none)
+//   8  : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the writer didn't
+//                       supply one — used as the composite tiebreaker)
 //   16 : offset        (uint64; byte offset of frame in block)
 //   24 : reserved      (uint64; zeroed)
 #define INDEX_ENTRY_SIZE 32
@@ -99,7 +100,8 @@ private:
 
 // v2 frame header: 16 + 8 + 4 + 4 = 32 bytes (8-byte aligned, payload at +32).
 //   0  : uuid[16]
-//   16 : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the stream has none)
+//   16 : secondary_key (int64; NANOTS_SEC_KEY_UNSET if the writer didn't
+//                       supply one)
 //   24 : size          (uint32)
 //   28 : flags         (uint32 — widened from u8 in v2)
 #define FRAME_HEADER_SIZE 32
@@ -108,47 +110,50 @@ private:
 #define FRAME_SIZE_OFFSET       24
 #define FRAME_FLAGS_OFFSET      28
 
-// Sentinel for "no secondary key on this frame". Streams either always have
-// one or never have one; the choice is fixed at the first write into the
-// stream and stored in segments.has_secondary_key.
+// Default tiebreaker value for callers that don't supply a real secondary
+// key. INT64_MIN is the smallest possible int64, so under the composite
+// (timestamp, secondary_key) ordering this acts as "smaller than any real
+// key" — i.e. a stream that always passes this sentinel sees the classic
+// "timestamp strictly monotonic" rule. Any other int64 (including 0) is a
+// real key and participates in the tiebreaker.
 #define NANOTS_SEC_KEY_UNSET INT64_MIN
 
 struct block_header {
-  int64_t block_start_timestamp{0};
-  uint32_t n_valid_indexes{0};
-  uint32_t block_feature_bits{0};
+    int64_t block_start_timestamp{0};
+    uint32_t n_valid_indexes{0};
+    uint32_t block_feature_bits{0};
 };
 
 struct index_entry {
-  int64_t timestamp{0};
-  int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
-  uint64_t offset{0};
-  uint64_t reserved{0};
+    int64_t timestamp{0};
+    int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
+    uint64_t offset{0};
+    uint64_t reserved{0};
 };
 
 struct block {
-  int64_t id{0};
-  int64_t idx{0};
+    int64_t id{0};
+    int64_t idx{0};
 };
 
 struct segment {
-  int64_t id{0};
-  std::string stream_tag;
-  std::string metadata;
-  int64_t sequence{0};
+    int64_t id{0};
+    std::string stream_tag;
+    std::string metadata;
+    int64_t sequence{0};
 };
 
 struct segment_block {
-  int64_t id{0};
-  int64_t segment_id{0};
-  int64_t sequence{0};
-  int64_t block_id{0};
-  int64_t block_idx{0};
-  int64_t start_timestamp{0};
-  int64_t end_timestamp{0};
-  int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
-  int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
-  uint8_t uuid[16];
+    int64_t id{0};
+    int64_t segment_id{0};
+    int64_t sequence{0};
+    int64_t block_id{0};
+    int64_t block_idx{0};
+    int64_t start_timestamp{0};
+    int64_t end_timestamp{0};
+    int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
+    uint8_t uuid[16];
 };
 
 // ---------------------------------------------------------------------------
@@ -167,43 +172,45 @@ struct segment_block {
 // Within a single process only. Cross-process readers are not protected.
 //
 class NANOTS_API nanots_epoch_registry {
- public:
-  static constexpr uint64_t INACTIVE = UINT64_MAX;
+public:
+    static constexpr uint64_t INACTIVE = UINT64_MAX;
 
-  struct Slot {
-    std::atomic<uint64_t> epoch{INACTIVE};
-    std::atomic<int64_t>  heartbeat_us{0};
-  };
+    struct Slot {
+      std::atomic<uint64_t> epoch{INACTIVE};
+      std::atomic<int64_t> heartbeat_us{0};
+    };
 
-  // Hot-path operations.
-  uint64_t global_epoch_load() const {
-    return _global_epoch.load(std::memory_order_acquire);
-  }
-  uint64_t global_epoch_bump() {
-    return _global_epoch.fetch_add(1, std::memory_order_release);
-  }
+    // Hot-path operations.
+    uint64_t global_epoch_load() const {
+      return _global_epoch.load(std::memory_order_acquire);
+    }
 
-  // Returns true if no active slot's epoch is <= retired_epoch. Slots whose
-  // heartbeat is older than NANOTS_HEARTBEAT_TIMEOUT_US are treated as dead
-  // and ignored.
-  bool can_recycle(uint64_t retired_epoch, int64_t now_us) const;
+    uint64_t global_epoch_bump() {
+      return _global_epoch.fetch_add(1, std::memory_order_release);
+    }
 
-  // Accessor for slot_guard.
-  Slot& slot(uint32_t id);
+    // Returns true if no active slot's epoch is <= retired_epoch. Slots whose
+    // heartbeat is older than NANOTS_HEARTBEAT_TIMEOUT_US are treated as dead
+    // and ignored.
+    bool can_recycle(uint64_t retired_epoch, int64_t now_us) const;
 
-  // Acquire/release; called by nanots_slot_guard.
-  uint32_t acquire_slot();
-  void     release_slot(uint32_t id);
+    // Accessor for slot_guard.
+    Slot& slot(uint32_t id);
 
-  // Path-keyed singleton accessor. Same path string returns the same registry
-  // for the lifetime of any caller holding the shared_ptr.
-  static std::shared_ptr<nanots_epoch_registry> get_or_create(
-      const std::string& file_path);
+    // Acquire/release; called by nanots_slot_guard.
+    uint32_t acquire_slot();
+    void release_slot(uint32_t id);
 
- private:
-  std::atomic<uint64_t>               _global_epoch{1};
-  mutable std::mutex                  _slots_mu;
-  std::vector<std::unique_ptr<Slot>>  _slots;
+    // Path-keyed singleton accessor. Same path string returns the same registry
+    // for the lifetime of any caller holding the shared_ptr.
+    static std::shared_ptr<nanots_epoch_registry> get_or_create(
+        const std::string& file_path
+    );
+
+private:
+    std::atomic<uint64_t> _global_epoch{1};
+    mutable std::mutex _slots_mu;
+    std::vector<std::unique_ptr<Slot>> _slots;
 };
 
 // Heartbeat timeout: a slot whose last heartbeat is older than this is
@@ -223,28 +230,28 @@ constexpr int64_t NANOTS_HEARTBEAT_TIMEOUT_US = 60LL * 1000 * 1000;  // 60s
 // Move-only.
 //
 class NANOTS_API nanots_slot_guard {
- public:
-  nanots_slot_guard() = default;
-  explicit nanots_slot_guard(std::shared_ptr<nanots_epoch_registry> registry);
-  ~nanots_slot_guard();
+public:
+    nanots_slot_guard() = default;
+    explicit nanots_slot_guard(std::shared_ptr<nanots_epoch_registry> registry);
+    ~nanots_slot_guard();
 
-  nanots_slot_guard(const nanots_slot_guard&)            = delete;
-  nanots_slot_guard& operator=(const nanots_slot_guard&) = delete;
-  nanots_slot_guard(nanots_slot_guard&& other) noexcept;
-  nanots_slot_guard& operator=(nanots_slot_guard&& other) noexcept;
+    nanots_slot_guard(const nanots_slot_guard&)            = delete;
+    nanots_slot_guard& operator=(const nanots_slot_guard&) = delete;
+    nanots_slot_guard(nanots_slot_guard&& other) noexcept;
+    nanots_slot_guard& operator=(nanots_slot_guard&& other) noexcept;
 
-  // Publishes the latest global_epoch to our slot and updates the heartbeat.
-  // Call at the start of every iterator operation. No-op if !active().
-  void op_begin();
+    // Publishes the latest global_epoch to our slot and updates the heartbeat.
+    // Call at the start of every iterator operation. No-op if !active().
+    void op_begin();
 
-  // True if this guard owns a slot.
-  bool active() const { return _slot_id != UINT32_MAX; }
+    // True if this guard owns a slot.
+    bool active() const { return _slot_id != UINT32_MAX; }
 
- private:
-  void _release() noexcept;
+private:
+    void _release() noexcept;
 
-  std::shared_ptr<nanots_epoch_registry> _registry;
-  uint32_t                                _slot_id{UINT32_MAX};
+    std::shared_ptr<nanots_epoch_registry> _registry;
+    uint32_t _slot_id{UINT32_MAX};
 };
 
 // ---------------------------------------------------------------------------
@@ -261,341 +268,360 @@ class NANOTS_API nanots_slot_guard {
 // assertions, etc.) without churning all the call sites again.
 //
 class NANOTS_API nanots_op_scope {
- public:
-  explicit nanots_op_scope(nanots_slot_guard& guard) : _guard(guard) {
-    _guard.op_begin();
-  }
-  ~nanots_op_scope() = default;
+public:
+    explicit nanots_op_scope(nanots_slot_guard& guard) : _guard(guard) {
+      _guard.op_begin();
+    }
+    ~nanots_op_scope() = default;
 
-  nanots_op_scope(const nanots_op_scope&)            = delete;
-  nanots_op_scope& operator=(const nanots_op_scope&) = delete;
-  nanots_op_scope(nanots_op_scope&&)                 = delete;
-  nanots_op_scope& operator=(nanots_op_scope&&)      = delete;
+    nanots_op_scope(const nanots_op_scope&)            = delete;
+    nanots_op_scope& operator=(const nanots_op_scope&) = delete;
+    nanots_op_scope(nanots_op_scope&&)                 = delete;
+    nanots_op_scope& operator=(nanots_op_scope&&)      = delete;
 
- private:
-  nanots_slot_guard& _guard;
+private:
+    nanots_slot_guard& _guard;
 };
 
 struct NANOTS_API write_context final {
-  write_context() = default;
-  write_context(const write_context&) = delete;
-  write_context& operator=(const write_context&) = delete;
-  write_context(write_context&& other) = default;
-  write_context& operator=(write_context&& other) = default;
+    write_context() = default;
+    write_context(const write_context&) = delete;
+    write_context& operator=(const write_context&) = delete;
+    write_context(write_context&& other) = default;
+    write_context& operator=(write_context&& other) = default;
 
-  ~write_context();
+    ~write_context();
 
-  std::string metadata;
-  std::string stream_tag;
-  std::optional<int64_t> last_timestamp;
-  std::optional<int64_t> last_secondary_key;
-  std::optional<segment> current_segment;
-  std::optional<segment_block> current_block;
-  nts_file file;
-  nts_memory_map mm;
-  std::string file_name;
-  uint32_t _block_size{0};
+    std::string metadata;
+    std::string stream_tag;
+    std::optional<int64_t> last_timestamp;
+    std::optional<int64_t> last_secondary_key;
+    std::optional<segment> current_segment;
+    std::optional<segment_block> current_block;
+    nts_file file;
+    nts_memory_map mm;
+    std::string file_name;
+    uint32_t _block_size{0};
 };
 
 class NANOTS_API nanots_writer {
  public:
-  nanots_writer(const std::string& file_name, bool auto_reclaim = false);
-  nanots_writer(const nanots_writer&) = delete;
-  nanots_writer(nanots_writer&&) = default;
-  nanots_writer& operator=(const nanots_writer&) = delete;
-  nanots_writer& operator=(nanots_writer&&) = default;
-  ~nanots_writer() = default;
+    nanots_writer(const std::string& file_name, bool auto_reclaim = false);
+    nanots_writer(const nanots_writer&) = delete;
+    nanots_writer(nanots_writer&&) = default;
+    nanots_writer& operator=(const nanots_writer&) = delete;
+    nanots_writer& operator=(nanots_writer&&) = default;
+    ~nanots_writer() = default;
 
-  write_context create_write_context(const std::string& stream_tag,
-                                     const std::string& metadata);
+    write_context create_write_context(
+        const std::string& stream_tag,
+        const std::string& metadata
+    );
 
-  // Frames are ordered by the COMPOSITE (timestamp, secondary_key) — that
-  // pair must be strictly greater than the previous frame's composite. So:
-  //   - timestamp may repeat; secondary_key must then strictly increase
-  //   - if timestamp strictly increases, secondary_key may be anything
-  // Default secondary_key = NANOTS_SEC_KEY_UNSET (= INT64_MIN) — the smallest
-  // possible value, equivalent to "no tiebreaker." A stream that always
-  // writes with the default gets the classic "timestamp strictly monotonic"
-  // behavior because (t, MIN) > (last_t, MIN) iff t > last_t.
-  void write(write_context& wctx,
-             const uint8_t* data,
-             size_t size,
-             uint32_t flags,
-             int64_t timestamp,
-             int64_t secondary_key = NANOTS_SEC_KEY_UNSET);
+    // Frames are ordered by the COMPOSITE (timestamp, secondary_key) — that
+    // pair must be strictly greater than the previous frame's composite. So:
+    //   - timestamp may repeat; secondary_key must then strictly increase
+    //   - if timestamp strictly increases, secondary_key may be anything
+    // Default secondary_key = NANOTS_SEC_KEY_UNSET (= INT64_MIN) — the smallest
+    // possible value, equivalent to "no tiebreaker." A stream that always
+    // writes with the default gets the classic "timestamp strictly monotonic"
+    // behavior because (t, MIN) > (last_t, MIN) iff t > last_t.
+    void write(
+        write_context& wctx,
+        const uint8_t* data,
+        size_t size,
+        uint32_t flags,
+        int64_t timestamp,
+        int64_t secondary_key = NANOTS_SEC_KEY_UNSET
+    );
 
-  static void free_blocks(const std::string& file_name,
-                          const std::string& stream_tag,
-                          int64_t start_timestamp,
-                          int64_t end_timestamp);
+    static void free_blocks(
+        const std::string& file_name,
+        const std::string& stream_tag,
+        int64_t start_timestamp,
+        int64_t end_timestamp
+    );
 
-  // Preallocated: fixed-size file with n_blocks slots, never grows.
-  // Pass n_blocks == 0 to create a growable file (see allocate_growable).
-  static void allocate(const std::string& file_name,
-                       uint32_t block_size,
-                       uint32_t n_blocks);
+    // Preallocated: fixed-size file with n_blocks slots, never grows.
+    // Pass n_blocks == 0 to create a growable file (see allocate_growable).
+    static void allocate(
+        const std::string& file_name,
+        uint32_t block_size,
+        uint32_t n_blocks
+    );
 
-  // Growable: file starts at just the header and extends on demand.
-  // max_blocks == 0 means unbounded (grow until disk is full).
-  static void allocate_growable(const std::string& file_name,
-                                uint32_t block_size,
-                                uint32_t max_blocks = 0);
+    // Growable: file starts at just the header and extends on demand.
+    // max_blocks == 0 means unbounded (grow until disk is full).
+    static void allocate_growable(
+        const std::string& file_name,
+        uint32_t block_size,
+        uint32_t max_blocks = 0
+    );
 
-  bool is_growable() const { return _n_blocks == 0; }
+    bool is_growable() const { return _n_blocks == 0; }
 
-  // Grow the file by some number of blocks (BoltDB-style: doubles up to a
-  // 1 GiB-per-grow cap, then linear). Caller must already hold a sqlite
-  // IMMEDIATE transaction. Returns the first new block (status='reserved');
-  // any extras are inserted as 'free'. Returns nullopt if max_blocks cap
-  // is already reached. Public only so _db_get_block can call it; treat as
-  // internal.
-  std::optional<block> _grow_blocks(const nts_sqlite_conn& conn);
+    // Grow the file by some number of blocks (BoltDB-style: doubles up to a
+    // 1 GiB-per-grow cap, then linear). Caller must already hold a sqlite
+    // IMMEDIATE transaction. Returns the first new block (status='reserved');
+    // any extras are inserted as 'free'. Returns nullopt if max_blocks cap
+    // is already reached. Public only so _db_get_block can call it; treat as
+    // internal.
+    std::optional<block> _grow_blocks(const nts_sqlite_conn& conn);
 
  private:
 
-  // EBR limbo: blocks the writer has retired (catalog ops done, but bytes
-  // not yet overwritten). _limbo entries that have cleared EBR safety get
-  // migrated to _ready, ready to be consumed by the next acquire.
-  struct LimboEntry {
-    int64_t  block_id;
-    int64_t  block_idx;
-    uint64_t retired_epoch;
-  };
+    // EBR limbo: blocks the writer has retired (catalog ops done, but bytes
+    // not yet overwritten). _limbo entries that have cleared EBR safety get
+    // migrated to _ready, ready to be consumed by the next acquire.
+    struct LimboEntry {
+        int64_t  block_id;
+        int64_t  block_idx;
+        uint64_t retired_epoch;
+    };
 
-  // Cap on outstanding limbo entries. If a long-stalled reader prevents
-  // any limbo entry from clearing, retire calls throw rather than grow
-  // unboundedly.
-  static constexpr size_t LIMBO_MAX_ENTRIES = 1024;
+    // Cap on outstanding limbo entries. If a long-stalled reader prevents
+    // any limbo entry from clearing, retire calls throw rather than grow
+    // unboundedly.
+    static constexpr size_t LIMBO_MAX_ENTRIES = 1024;
 
-  // Top-level block acquisition under EBR. Tries (1) ready queue, (2) free
-  // block, (3) growable extension, (4) retire-into-limbo + ready queue with
-  // bounded retries. Returned block is always safe to pass through
-  // _recycle_block: either truly free (already zeroed), freshly grown, or
-  // an EBR-cleared retired block.
-  block _acquire_writable_block(const nts_sqlite_conn& conn);
+    // Top-level block acquisition under EBR. Tries (1) ready queue, (2) free
+    // block, (3) growable extension, (4) retire-into-limbo + ready queue with
+    // bounded retries. Returned block is always safe to pass through
+    // _recycle_block: either truly free (already zeroed), freshly grown, or
+    // an EBR-cleared retired block.
+    block _acquire_writable_block(const nts_sqlite_conn& conn);
 
-  // Move limbo entries that have cleared EBR safety into the ready queue.
-  // Caller must NOT hold _limbo_mu.
-  void _scan_limbo();
+    // Move limbo entries that have cleared EBR safety into the ready queue.
+    // Caller must NOT hold _limbo_mu.
+    void _scan_limbo();
 
-  std::string _file_name;
-  uint64_t _file_size;
-  nts_file _file;
-  nts_memory_map _file_header_mm;
-  uint8_t* _file_header_p;
-  uint32_t _block_size;
-  uint32_t _n_blocks;       // 0 == growable mode (sentinel)
-  uint32_t _max_blocks;     // growable cap; 0 == unbounded; ignored if !growable
-  bool _auto_reclaim;
-  std::set<std::string> _active_stream_tags;
+    std::string _file_name;
+    uint64_t _file_size;
+    nts_file _file;
+    nts_memory_map _file_header_mm;
+    uint8_t* _file_header_p;
+    uint32_t _block_size;
+    uint32_t _n_blocks;       // 0 == growable mode (sentinel)
+    uint32_t _max_blocks;     // growable cap; 0 == unbounded; ignored if !growable
+    bool _auto_reclaim;
+    std::set<std::string> _active_stream_tags;
 
-  // EBR state. _epoch is shared with every iterator and writer on this file.
-  std::shared_ptr<nanots_epoch_registry> _epoch;
-  std::deque<LimboEntry>                 _limbo;
-  std::deque<LimboEntry>                 _ready;
-  std::mutex                             _limbo_mu;
+    // EBR state. _epoch is shared with every iterator and writer on this file.
+    std::shared_ptr<nanots_epoch_registry> _epoch;
+    std::deque<LimboEntry> _limbo;
+    std::deque<LimboEntry> _ready;
+    std::mutex _limbo_mu;
 };
 
 struct contiguous_segment {
-  int64_t segment_id{0};
-  int64_t start_timestamp{0};
-  int64_t end_timestamp{0};
+    int64_t segment_id{0};
+    int64_t start_timestamp{0};
+    int64_t end_timestamp{0};
 };
 
 class NANOTS_API nanots_reader {
  public:
-  nanots_reader(const std::string& file_name);
-  nanots_reader(const nanots_reader&) = delete;
-  nanots_reader(nanots_reader&&) = default;
-  nanots_reader& operator=(const nanots_reader&) = delete;
-  nanots_reader& operator=(nanots_reader&&) = default;
-  ~nanots_reader() = default;
+    nanots_reader(const std::string& file_name);
+    nanots_reader(const nanots_reader&) = delete;
+    nanots_reader(nanots_reader&&) = default;
+    nanots_reader& operator=(const nanots_reader&) = delete;
+    nanots_reader& operator=(nanots_reader&&) = default;
+    ~nanots_reader() = default;
 
-  // Callback signature is:
-  //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
-  // `secondary_key` is NANOTS_SEC_KEY_UNSET for frames whose writer didn't
-  // supply one.
-  void read(
-      const std::string& stream_tag,
-      int64_t start_timestamp,
-      int64_t end_timestamp,
-      const std::function<
-          void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback);
-  
-  std::vector<std::string> query_stream_tags(int64_t start_timestamp, int64_t end_timestamp);
+    // Callback signature is:
+    //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
+    // `secondary_key` is NANOTS_SEC_KEY_UNSET for frames whose writer didn't
+    // supply one.
+    void read(
+        const std::string& stream_tag,
+        int64_t start_timestamp,
+        int64_t end_timestamp,
+        const std::function<
+            void(const uint8_t*, size_t, uint32_t, int64_t, int64_t, int64_t, const std::string&)>& callback
+    );
 
-  std::vector<contiguous_segment> query_contiguous_segments(
-      const std::string& stream_tag,
-      int64_t start_timestamp,
-      int64_t end_timestamp);
+    std::vector<std::string> query_stream_tags(
+        int64_t start_timestamp,
+        int64_t end_timestamp
+    );
+
+    std::vector<contiguous_segment> query_contiguous_segments(
+        const std::string& stream_tag,
+        int64_t start_timestamp,
+        int64_t end_timestamp
+    );
 
  private:
-  std::string _file_name;
-  nts_file _file;
-  uint32_t _block_size;
-  uint32_t _n_blocks;
+    std::string _file_name;
+    nts_file _file;
+    uint32_t _block_size;
+    uint32_t _n_blocks;
 
-  // EBR slot. Acquired on construction, released on destruction. read() opens
-  // a critical section for its duration so the writer cannot overwrite block
-  // bytes while the callback is dereferencing them.
-  nanots_slot_guard _slot_guard;
+    // EBR slot. Acquired on construction, released on destruction. read() opens
+    // a critical section for its duration so the writer cannot overwrite block
+    // bytes while the callback is dereferencing them.
+    nanots_slot_guard _slot_guard;
 };
 
 struct frame_info {
-  const uint8_t* data{nullptr};
-  size_t size{0};
-  uint32_t flags{0};
-  int64_t timestamp{0};
-  int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
-  int64_t block_sequence{0};
+    const uint8_t* data{nullptr};
+    size_t size{0};
+    uint32_t flags{0};
+    int64_t timestamp{0};
+    int64_t secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t block_sequence{0};
 };
 
 struct block_info {
-  int64_t block_idx{0};
-  int64_t block_sequence{0};
-  int64_t segment_id{0};
-  std::string metadata;
-  std::string uuid_hex;
-  int64_t start_timestamp{0};
-  int64_t end_timestamp{0};
-  int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
-  int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t block_idx{0};
+    int64_t block_sequence{0};
+    int64_t segment_id{0};
+    std::string metadata;
+    std::string uuid_hex;
+    int64_t start_timestamp{0};
+    int64_t end_timestamp{0};
+    int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
+    int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
 
-  // Loaded block data
-  nts_memory_map mm;
-  uint8_t* block_p{nullptr};
-  uint32_t n_valid_indexes{0};
-  uint8_t uuid[16];
-  bool is_loaded{false};
+    // Loaded block data
+    nts_memory_map mm;
+    uint8_t* block_p{nullptr};
+    uint32_t n_valid_indexes{0};
+    uint8_t uuid[16];
+    bool is_loaded{false};
 };
 
 class NANOTS_API nanots_iterator {
  public:
-  nanots_iterator(const std::string& file_name, const std::string& stream_tag);
-  nanots_iterator(const nanots_iterator&) = delete;
-  nanots_iterator(nanots_iterator&&) = default;
-  nanots_iterator& operator=(const nanots_iterator&) = delete;
-  nanots_iterator& operator=(nanots_iterator&&) = default;
-  ~nanots_iterator() = default;
+    nanots_iterator(
+        const std::string& file_name,
+        const std::string& stream_tag
+    );
+    nanots_iterator(const nanots_iterator&) = delete;
+    nanots_iterator(nanots_iterator&&) = default;
+    nanots_iterator& operator=(const nanots_iterator&) = delete;
+    nanots_iterator& operator=(nanots_iterator&&) = default;
+    ~nanots_iterator() = default;
 
-  // Iterator interface
-  bool valid() const { return _valid; }
-  const frame_info& operator*() const { return _current_frame; }
-  const frame_info* operator->() const { return &_current_frame; }
+    // Iterator interface
+    bool valid() const { return _valid; }
+    const frame_info& operator*() const { return _current_frame; }
+    const frame_info* operator->() const { return &_current_frame; }
 
-  // Navigation
-  nanots_iterator& operator++();  // Move to next frame
-  nanots_iterator& operator--();  // Move to previous frame
+    // Navigation
+    nanots_iterator& operator++();  // Move to next frame
+    nanots_iterator& operator--();  // Move to previous frame
 
-  // Find the first frame whose composite (timestamp, secondary_key) is >=
-  // the requested composite. Pass `secondary_key` to seek to a specific
-  // tiebroken position; omit it (defaults to NANOTS_SEC_KEY_UNSET) to land
-  // on the first frame at the requested timestamp regardless of sec_key —
-  // because INT64_MIN is the smallest possible sec_key.
-  bool find(int64_t timestamp,
-            int64_t secondary_key = NANOTS_SEC_KEY_UNSET);
+    // Find the first frame whose composite (timestamp, secondary_key) is >=
+    // the requested composite. Pass `secondary_key` to seek to a specific
+    // tiebroken position; omit it (defaults to NANOTS_SEC_KEY_UNSET) to land
+    // on the first frame at the requested timestamp regardless of sec_key —
+    // because INT64_MIN is the smallest possible sec_key.
+    bool find(int64_t timestamp,
+              int64_t secondary_key = NANOTS_SEC_KEY_UNSET
+    );
 
-  bool seek_end();               // Go to last frame
-  void reset();                   // Go to first frame
+    bool seek_end();               // Go to last frame
+    void reset();                   // Go to first frame
 
-  // Utility
-  int64_t current_block_sequence() const { return _current_block_sequence; }
-  const std::string& current_metadata() const;
+    // Utility
+    int64_t current_block_sequence() const { return _current_block_sequence; }
+    const std::string& current_metadata() const;
 
  private:
-  // In-memory index of all blocks in this stream, sorted by start_ts
-  // (equivalently by (segment_id, sequence) since both are monotonic for a
-  // given stream). Built lazily on first navigation operation; refreshed when
-  // a stale entry is detected or when navigation runs off the cached end.
-  // Replaces per-op SQL queries in _find_block_for_timestamp /
-  // _get_first/last/next/prev_block with in-memory binary search.
-  struct BlockRange {
-    int64_t start_ts;
-    int64_t end_ts;       // 0 = open block (currently being written)
-    int64_t segment_id;
-    int64_t sequence;
-    int64_t start_sk;     // NANOTS_SEC_KEY_UNSET if stream has no sec key
-    int64_t end_sk;       // 0 boundary semantics same as end_ts
-  };
+    // In-memory index of all blocks in this stream, sorted by start_ts
+    // (equivalently by (segment_id, sequence) since both are monotonic for a
+    // given stream). Built lazily on first navigation operation; refreshed when
+    // a stale entry is detected or when navigation runs off the cached end.
+    // Replaces per-op SQL queries in _find_block_for_timestamp /
+    // _get_first/last/next/prev_block with in-memory binary search.
+    struct BlockRange {
+      int64_t start_ts;
+      int64_t end_ts;       // 0 = open block (currently being written)
+      int64_t segment_id;
+      int64_t sequence;
+      int64_t start_sk;     // NANOTS_SEC_KEY_UNSET if stream has no sec key
+      int64_t end_sk;       // 0 boundary semantics same as end_ts
+    };
 
-  block_info* _get_block_by_segment_and_sequence(int64_t segment_id, int64_t sequence);
-  block_info* _get_first_block();
-  block_info* _get_last_block();
-  block_info* _get_next_block();
-  block_info* _get_prev_block();
-  block_info* _find_block_for_composite(int64_t timestamp, int64_t sec_key);
+    block_info* _get_block_by_segment_and_sequence(int64_t segment_id, int64_t sequence);
+    block_info* _get_first_block();
+    block_info* _get_last_block();
+    block_info* _get_next_block();
+    block_info* _get_prev_block();
+    block_info* _find_block_for_composite(int64_t timestamp, int64_t sec_key);
 
-  // Build (or rebuild) the timestamp index from SQL. _ensure_ts_index is the
-  // lazy entry point used by navigation methods.
-  void   _ensure_ts_index();
-  void   _refresh_ts_index();
+    // Build (or rebuild) the timestamp index from SQL. _ensure_ts_index is the
+    // lazy entry point used by navigation methods.
+    void _ensure_ts_index();
+    void _refresh_ts_index();
 
-  // Returns the position in _ts_index of the block matching ts, or
-  // _ts_index.size() if none. Matches the old SQL semantics: first prefers a
-  // block that covers ts (start_ts <= ts <= end_ts, or end_ts == 0); otherwise
-  // returns the first block with start_ts >= ts.
-  // Composite lower_bound: returns the position of the first block whose
-  // (start_ts, start_sk) is >= (ts, sk), or the block that covers it.
-  size_t _ts_index_find(int64_t ts, int64_t sk) const;
+    // Returns the position in _ts_index of the block matching ts, or
+    // _ts_index.size() if none. Matches the old SQL semantics: first prefers a
+    // block that covers ts (start_ts <= ts <= end_ts, or end_ts == 0); otherwise
+    // returns the first block with start_ts >= ts.
+    // Composite lower_bound: returns the position of the first block whose
+    // (start_ts, start_sk) is >= (ts, sk), or the block that covers it.
+    size_t _ts_index_find(int64_t ts, int64_t sk) const;
 
-  // True if _ts_index_pos matches (current_segment_id, current_block_sequence).
-  bool   _ts_index_pos_is_valid() const;
+    // True if _ts_index_pos matches (current_segment_id, current_block_sequence).
+    bool _ts_index_pos_is_valid() const;
 
-  // Linear search _ts_index for (current_segment_id, current_block_sequence)
-  // and update _ts_index_pos. Returns true on success.
-  bool   _ts_index_relocate();
+    // Linear search _ts_index for (current_segment_id, current_block_sequence)
+    // and update _ts_index_pos. Returns true on success.
+    bool _ts_index_relocate();
 
-  bool _load_block_data(block_info& block);
-  bool _load_current_frame();
+    bool _load_block_data(block_info& block);
+    bool _load_current_frame();
 
-  std::string _file_name;
-  std::string _stream_tag;
-  nts_file _file;
-  uint32_t _block_size;
+    std::string _file_name;
+    std::string _stream_tag;
+    nts_file _file;
+    uint32_t _block_size;
 
-  // Current position
-  int64_t _current_block_sequence;
-  int64_t _current_segment_id;
-  size_t _current_frame_idx;
-  int64_t _current_block_start_ts;
-  int64_t _current_block_end_ts;
+    // Current position
+    int64_t _current_block_sequence;
+    int64_t _current_segment_id;
+    size_t _current_frame_idx;
+    int64_t _current_block_start_ts;
+    int64_t _current_block_end_ts;
 
-  // Cache of visited blocks (segment_id:sequence -> block_info)
-  // Using string key for simplicity: "segment_id:sequence"
-  std::unordered_map<std::string, block_info> _block_cache;
+    // Cache of visited blocks (segment_id:sequence -> block_info)
+    // Using string key for simplicity: "segment_id:sequence"
+    std::unordered_map<std::string, block_info> _block_cache;
 
-  // Timestamp index. See BlockRange above. _ts_index_pos tracks the position
-  // in _ts_index corresponding to (_current_segment_id, _current_block_sequence)
-  // so operator++/-- can advance via array indexing instead of SQL.
-  std::vector<BlockRange> _ts_index;
-  bool                    _ts_index_filled{false};
-  size_t                  _ts_index_pos{0};
+    // Timestamp index. See BlockRange above. _ts_index_pos tracks the position
+    // in _ts_index corresponding to (_current_segment_id, _current_block_sequence)
+    // so operator++/-- can advance via array indexing instead of SQL.
+    std::vector<BlockRange> _ts_index;
+    bool _ts_index_filled{false};
+    size_t _ts_index_pos{0};
 
-  // Cached current frame
-  frame_info _current_frame;
-  bool _valid;
-  bool _initialized;
+    // Cached current frame
+    frame_info _current_frame;
+    bool _valid;
+    bool _initialized;
 
-  // Lazily-initialized database connection for read operations
-  std::optional<nts_sqlite_conn> _db_conn;
-  nts_sqlite_conn& _ensure_db_connection();
+    // Lazily-initialized database connection for read operations
+    std::optional<nts_sqlite_conn> _db_conn;
+    nts_sqlite_conn& _ensure_db_connection();
 
-  // Cached prepared statements (lazily initialized on first use)
-  std::optional<nts_sqlite_stmt> _stmt_get_block_by_id;
-  std::optional<nts_sqlite_stmt> _stmt_get_first_block;
-  std::optional<nts_sqlite_stmt> _stmt_get_last_block;
-  std::optional<nts_sqlite_stmt> _stmt_next_in_segment;
-  std::optional<nts_sqlite_stmt> _stmt_next_cross_segment;
-  std::optional<nts_sqlite_stmt> _stmt_prev_in_segment;
-  std::optional<nts_sqlite_stmt> _stmt_prev_cross_segment;
-  std::optional<nts_sqlite_stmt> _stmt_find_block_containing;
-  std::optional<nts_sqlite_stmt> _stmt_find_block_ge;
+    // Cached prepared statements (lazily initialized on first use)
+    std::optional<nts_sqlite_stmt> _stmt_get_block_by_id;
+    std::optional<nts_sqlite_stmt> _stmt_get_first_block;
+    std::optional<nts_sqlite_stmt> _stmt_get_last_block;
+    std::optional<nts_sqlite_stmt> _stmt_next_in_segment;
+    std::optional<nts_sqlite_stmt> _stmt_next_cross_segment;
+    std::optional<nts_sqlite_stmt> _stmt_prev_in_segment;
+    std::optional<nts_sqlite_stmt> _stmt_prev_cross_segment;
+    std::optional<nts_sqlite_stmt> _stmt_find_block_containing;
+    std::optional<nts_sqlite_stmt> _stmt_find_block_ge;
 
-  // EBR slot. Acquired on construction, released on destruction. Each
-  // navigation operation (find, ++, --, reset, seek_end) calls op_begin()
-  // to publish the current global epoch + heartbeat. This is what permits
-  // the writer to know it's safe to physically recycle a block.
-  nanots_slot_guard _slot_guard;
+    // EBR slot. Acquired on construction, released on destruction. Each
+    // navigation operation (find, ++, --, reset, seek_end) calls op_begin()
+    // to publish the current global epoch + heartbeat. This is what permits
+    // the writer to know it's safe to physically recycle a block.
+    nanots_slot_guard _slot_guard;
 };
 
 #ifdef __cplusplus
@@ -622,27 +648,42 @@ typedef struct {
   int64_t block_sequence;
 } nanots_frame_info_t;
 
-typedef void (*nanots_read_callback_t)(const uint8_t* data,
-                                       size_t size,
-                                       uint32_t flags,
-                                       int64_t timestamp,
-                                       int64_t secondary_key,
-                                       int64_t block_sequence,
-                                       const char* metadata,
-                                       void* user_data);
+typedef void (*nanots_read_callback_t)(
+    const uint8_t* data,
+    size_t size,
+    uint32_t flags,
+    int64_t timestamp,
+    int64_t secondary_key,
+    int64_t block_sequence,
+    const char* metadata,
+    void* user_data
+);
 
-NANOTS_API nanots_ec_t nanots_writer_allocate_file(const char* file_name, uint32_t block_size, uint32_t n_blocks);
+NANOTS_API nanots_ec_t nanots_writer_allocate_file(
+    const char* file_name,
+    uint32_t block_size,
+    uint32_t n_blocks
+);
 
-NANOTS_API nanots_ec_t nanots_writer_allocate_growable_file(const char* file_name, uint32_t block_size, uint32_t max_blocks);
+NANOTS_API nanots_ec_t nanots_writer_allocate_growable_file(
+    const char* file_name,
+    uint32_t block_size,
+    uint32_t max_blocks
+);
 
 // writer
-NANOTS_API nanots_writer_t nanots_writer_create(const char* file_name, int auto_reclaim);
+NANOTS_API nanots_writer_t nanots_writer_create(
+    const char* file_name,
+    int auto_reclaim
+);
 
 NANOTS_API void nanots_writer_destroy(nanots_writer_t writer);
 
-NANOTS_API nanots_write_context_t nanots_writer_create_context(nanots_writer_t writer,
-                                                    const char* stream_tag,
-                                                    const char* metadata);
+NANOTS_API nanots_write_context_t nanots_writer_create_context(
+    nanots_writer_t writer,
+    const char* stream_tag,
+    const char* metadata
+);
 
 NANOTS_API void nanots_write_context_destroy(nanots_write_context_t context);
 
@@ -652,30 +693,36 @@ NANOTS_API void nanots_write_context_destroy(nanots_write_context_t context);
 //
 // Argument order mirrors the C++ method: flags, then timestamp, then the
 // optional secondary key. The C ABI has no defaults — pass all 7 args.
-NANOTS_API nanots_ec_t nanots_writer_write(nanots_writer_t writer,
-                                    nanots_write_context_t context,
-                                    const uint8_t* data,
-                                    size_t size,
-                                    uint32_t flags,
-                                    int64_t timestamp,
-                                    int64_t secondary_key);
+NANOTS_API nanots_ec_t nanots_writer_write(
+    nanots_writer_t writer,
+    nanots_write_context_t context,
+    const uint8_t* data,
+    size_t size,
+    uint32_t flags,
+    int64_t timestamp,
+    int64_t secondary_key
+);
 
-NANOTS_API nanots_ec_t nanots_writer_free_blocks(const char* file_name,
-                                      const char* stream_tag,
-                                      int64_t start_timestamp,
-                                      int64_t end_timestamp);
+NANOTS_API nanots_ec_t nanots_writer_free_blocks(
+    const char* file_name,
+    const char* stream_tag,
+    int64_t start_timestamp,
+    int64_t end_timestamp
+);
 
 // reader
 NANOTS_API nanots_reader_t nanots_reader_create(const char* file_name);
 
 NANOTS_API void nanots_reader_destroy(nanots_reader_t reader);
 
-NANOTS_API nanots_ec_t nanots_reader_read(nanots_reader_t reader,
-                               const char* stream_tag,
-                               int64_t start_timestamp,
-                               int64_t end_timestamp,
-                               nanots_read_callback_t callback,
-                               void* user_data);
+NANOTS_API nanots_ec_t nanots_reader_read(
+    nanots_reader_t reader,
+    const char* stream_tag,
+    int64_t start_timestamp,
+    int64_t end_timestamp,
+    nanots_read_callback_t callback,
+    void* user_data
+);
 
 NANOTS_API nanots_ec_t nanots_reader_query_contiguous_segments(
     nanots_reader_t reader,
@@ -683,26 +730,33 @@ NANOTS_API nanots_ec_t nanots_reader_query_contiguous_segments(
     int64_t start_timestamp,
     int64_t end_timestamp,
     nanots_contiguous_segment_t** segments,
-    size_t* count);
+    size_t* count
+);
 
 NANOTS_API void nanots_free_contiguous_segments(nanots_contiguous_segment_t* segments);
 
-NANOTS_API nanots_ec_t nanots_reader_query_stream_tags_start(nanots_reader_t reader,
-                                                  int64_t start_timestamp,
-                                                  int64_t end_timestamp);
+NANOTS_API nanots_ec_t nanots_reader_query_stream_tags_start(
+    nanots_reader_t reader,
+    int64_t start_timestamp,
+    int64_t end_timestamp
+);
 
 NANOTS_API const char* nanots_reader_query_stream_tags_next(nanots_reader_t reader);
 
 // iterator
-NANOTS_API nanots_iterator_t nanots_iterator_create(const char* file_name,
-                                         const char* stream_tag);
+NANOTS_API nanots_iterator_t nanots_iterator_create(
+    const char* file_name,
+    const char* stream_tag
+);
+
 NANOTS_API void nanots_iterator_destroy(nanots_iterator_t iterator);
 
 NANOTS_API int nanots_iterator_valid(nanots_iterator_t iterator);
 
 NANOTS_API nanots_ec_t nanots_iterator_get_current_frame(
     nanots_iterator_t iterator,
-    nanots_frame_info_t* frame_info);
+    nanots_frame_info_t* frame_info
+);
 
 NANOTS_API nanots_ec_t nanots_iterator_next(nanots_iterator_t iterator);
 
@@ -711,9 +765,11 @@ NANOTS_API nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator);
 // Find the first frame whose composite (timestamp, secondary_key) is >= the
 // requested composite. Pass NANOTS_SEC_KEY_UNSET for `secondary_key` to land
 // on the first frame at the requested timestamp.
-NANOTS_API nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
-                                            int64_t timestamp,
-                                            int64_t secondary_key);
+NANOTS_API nanots_ec_t nanots_iterator_find(
+    nanots_iterator_t iterator,
+    int64_t timestamp,
+    int64_t secondary_key
+);
 
 NANOTS_API nanots_ec_t nanots_iterator_reset(nanots_iterator_t iterator);
 

--- a/nanots.h
+++ b/nanots.h
@@ -22,9 +22,11 @@ enum nanots_ec_t {
   NANOTS_EC_UNKNOWN = 12,
   NANOTS_EC_NOT_FOUND = 13,
   NANOTS_EC_BAD_MAGIC = 14,
-  NANOTS_EC_BAD_VERSION = 15,
-  NANOTS_EC_SECONDARY_KEY_MISMATCH = 16,
-  NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY = 17
+  NANOTS_EC_BAD_VERSION = 15
+  // Reserved 16-17 (previously SECONDARY_KEY_MISMATCH and
+  // NON_MONOTONIC_SECONDARY_KEY). Composite-key semantics fold both into
+  // NANOTS_EC_NON_MONOTONIC_TIMESTAMP, which now means "composite (ts,
+  // sec_key) is not strictly greater than the previous frame's composite."
 };
 
 }
@@ -134,10 +136,6 @@ struct segment {
   std::string stream_tag;
   std::string metadata;
   int64_t sequence{0};
-  // True if every write into this segment must include a secondary key.
-  // Locked at segment creation time and (for the stream as a whole) recorded
-  // on the first segment created for that stream tag — see _db_create_segment.
-  bool has_secondary_key{false};
 };
 
 struct segment_block {
@@ -311,15 +309,14 @@ class NANOTS_API nanots_writer {
   write_context create_write_context(const std::string& stream_tag,
                                      const std::string& metadata);
 
-  // `secondary_key` defaults to NANOTS_SEC_KEY_UNSET — pass any other int64
-  // to write into a *keyed* stream. The choice is fixed by the first write to
-  // a given stream tag; mixing keyed and unkeyed writes on the same stream is
-  // rejected with NANOTS_EC_SECONDARY_KEY_MISMATCH. Keys are strictly
-  // monotonic within a stream.
-  //
-  // Argument order: (timestamp, secondary_key) are grouped at the end as the
-  // frame's ordering keys, with flags before them so the unkeyed call shape
-  // is just write(wctx, data, size, flags, timestamp).
+  // Frames are ordered by the COMPOSITE (timestamp, secondary_key) — that
+  // pair must be strictly greater than the previous frame's composite. So:
+  //   - timestamp may repeat; secondary_key must then strictly increase
+  //   - if timestamp strictly increases, secondary_key may be anything
+  // Default secondary_key = NANOTS_SEC_KEY_UNSET (= INT64_MIN) — the smallest
+  // possible value, equivalent to "no tiebreaker." A stream that always
+  // writes with the default gets the classic "timestamp strictly monotonic"
+  // behavior because (t, MIN) > (last_t, MIN) iff t > last_t.
   void write(write_context& wctx,
              const uint8_t* data,
              size_t size,
@@ -416,7 +413,8 @@ class NANOTS_API nanots_reader {
 
   // Callback signature is:
   //   (data, size, flags, timestamp, secondary_key, block_sequence, metadata)
-  // `secondary_key` is NANOTS_SEC_KEY_UNSET for streams that don't use one.
+  // `secondary_key` is NANOTS_SEC_KEY_UNSET for frames whose writer didn't
+  // supply one.
   void read(
       const std::string& stream_tag,
       int64_t start_timestamp,
@@ -462,7 +460,6 @@ struct block_info {
   int64_t end_timestamp{0};
   int64_t start_secondary_key{NANOTS_SEC_KEY_UNSET};
   int64_t end_secondary_key{NANOTS_SEC_KEY_UNSET};
-  bool has_secondary_key{false};
 
   // Loaded block data
   nts_memory_map mm;
@@ -489,18 +486,21 @@ class NANOTS_API nanots_iterator {
   // Navigation
   nanots_iterator& operator++();  // Move to next frame
   nanots_iterator& operator--();  // Move to previous frame
-  bool find(int64_t timestamp);  // Find first frame >= timestamp
-  // Find first frame with secondary_key >= sec_key. Only valid on streams
-  // whose has_secondary_key == true; returns false otherwise.
-  bool find_by_secondary_key(int64_t sec_key);
+
+  // Find the first frame whose composite (timestamp, secondary_key) is >=
+  // the requested composite. Pass `secondary_key` to seek to a specific
+  // tiebroken position; omit it (defaults to NANOTS_SEC_KEY_UNSET) to land
+  // on the first frame at the requested timestamp regardless of sec_key —
+  // because INT64_MIN is the smallest possible sec_key.
+  bool find(int64_t timestamp,
+            int64_t secondary_key = NANOTS_SEC_KEY_UNSET);
+
   bool seek_end();               // Go to last frame
   void reset();                   // Go to first frame
 
   // Utility
   int64_t current_block_sequence() const { return _current_block_sequence; }
   const std::string& current_metadata() const;
-  // True if this stream stores a secondary key on every frame.
-  bool has_secondary_key();
 
  private:
   // In-memory index of all blocks in this stream, sorted by start_ts
@@ -523,8 +523,7 @@ class NANOTS_API nanots_iterator {
   block_info* _get_last_block();
   block_info* _get_next_block();
   block_info* _get_prev_block();
-  block_info* _find_block_for_timestamp(int64_t timestamp);
-  block_info* _find_block_for_secondary_key(int64_t sec_key);
+  block_info* _find_block_for_composite(int64_t timestamp, int64_t sec_key);
 
   // Build (or rebuild) the timestamp index from SQL. _ensure_ts_index is the
   // lazy entry point used by navigation methods.
@@ -535,11 +534,9 @@ class NANOTS_API nanots_iterator {
   // _ts_index.size() if none. Matches the old SQL semantics: first prefers a
   // block that covers ts (start_ts <= ts <= end_ts, or end_ts == 0); otherwise
   // returns the first block with start_ts >= ts.
-  size_t _ts_index_find(int64_t ts) const;
-
-  // Same as _ts_index_find but searches by secondary key. Only meaningful for
-  // streams whose has_secondary_key is true.
-  size_t _ts_index_find_by_sk(int64_t sk) const;
+  // Composite lower_bound: returns the position of the first block whose
+  // (start_ts, start_sk) is >= (ts, sk), or the block that covers it.
+  size_t _ts_index_find(int64_t ts, int64_t sk) const;
 
   // True if _ts_index_pos matches (current_segment_id, current_block_sequence).
   bool   _ts_index_pos_is_valid() const;
@@ -555,9 +552,6 @@ class NANOTS_API nanots_iterator {
   std::string _stream_tag;
   nts_file _file;
   uint32_t _block_size;
-  // Cached from the segments row for this stream. -1 = not yet known;
-  // 0 = no, 1 = yes.
-  int _has_secondary_key_cache{-1};
 
   // Current position
   int64_t _current_block_sequence;
@@ -714,16 +708,12 @@ NANOTS_API nanots_ec_t nanots_iterator_next(nanots_iterator_t iterator);
 
 NANOTS_API nanots_ec_t nanots_iterator_prev(nanots_iterator_t iterator);
 
+// Find the first frame whose composite (timestamp, secondary_key) is >= the
+// requested composite. Pass NANOTS_SEC_KEY_UNSET for `secondary_key` to land
+// on the first frame at the requested timestamp.
 NANOTS_API nanots_ec_t nanots_iterator_find(nanots_iterator_t iterator,
-                                     int64_t timestamp);
-
-// Returns NANOTS_EC_INVALID_ARGUMENT if the stream has no secondary key.
-NANOTS_API nanots_ec_t nanots_iterator_find_by_secondary_key(
-    nanots_iterator_t iterator,
-    int64_t secondary_key);
-
-// 1 if this iterator's stream stores secondary keys, 0 otherwise.
-NANOTS_API int nanots_iterator_has_secondary_key(nanots_iterator_t iterator);
+                                            int64_t timestamp,
+                                            int64_t secondary_key);
 
 NANOTS_API nanots_ec_t nanots_iterator_reset(nanots_iterator_t iterator);
 

--- a/ut/include/test_nanots.h
+++ b/ut/include/test_nanots.h
@@ -38,6 +38,19 @@ class test_nanots : public test_fixture {
   TEST(test_nanots::test_nanots_growable_basic);
   TEST(test_nanots::test_nanots_growable_doubling);
   TEST(test_nanots::test_nanots_growable_max_cap);
+  TEST(test_nanots::test_nanots_secondary_key_basic);
+  TEST(test_nanots::test_nanots_secondary_key_find);
+  TEST(test_nanots::test_nanots_secondary_key_mismatch);
+  TEST(test_nanots::test_nanots_secondary_key_monotonic);
+  TEST(test_nanots::test_nanots_v1_file_rejected);
+  TEST(test_nanots::test_nanots_secondary_key_cross_blocks);
+  TEST(test_nanots::test_nanots_secondary_key_bidirectional);
+  TEST(test_nanots::test_nanots_secondary_key_multi_segment);
+  TEST(test_nanots::test_nanots_secondary_key_unkeyed_stream_rejects_find);
+  TEST(test_nanots::test_nanots_secondary_key_mixed_streams_same_file);
+  TEST(test_nanots::test_nanots_secondary_key_sparse);
+  TEST(test_nanots::test_nanots_secondary_key_extreme_values);
+  TEST(test_nanots::test_nanots_secondary_key_reader_callback);
   RTF_FIXTURE_END();
 
   virtual ~test_nanots() throw() {}
@@ -80,4 +93,17 @@ class test_nanots : public test_fixture {
   void test_nanots_growable_basic();
   void test_nanots_growable_doubling();
   void test_nanots_growable_max_cap();
+  void test_nanots_secondary_key_basic();
+  void test_nanots_secondary_key_find();
+  void test_nanots_secondary_key_mismatch();
+  void test_nanots_secondary_key_monotonic();
+  void test_nanots_v1_file_rejected();
+  void test_nanots_secondary_key_cross_blocks();
+  void test_nanots_secondary_key_bidirectional();
+  void test_nanots_secondary_key_multi_segment();
+  void test_nanots_secondary_key_unkeyed_stream_rejects_find();
+  void test_nanots_secondary_key_mixed_streams_same_file();
+  void test_nanots_secondary_key_sparse();
+  void test_nanots_secondary_key_extreme_values();
+  void test_nanots_secondary_key_reader_callback();
 };

--- a/ut/include/test_nanots.h
+++ b/ut/include/test_nanots.h
@@ -40,17 +40,17 @@ class test_nanots : public test_fixture {
   TEST(test_nanots::test_nanots_growable_max_cap);
   TEST(test_nanots::test_nanots_secondary_key_basic);
   TEST(test_nanots::test_nanots_secondary_key_find);
-  TEST(test_nanots::test_nanots_secondary_key_mismatch);
   TEST(test_nanots::test_nanots_secondary_key_monotonic);
   TEST(test_nanots::test_nanots_v1_file_rejected);
   TEST(test_nanots::test_nanots_secondary_key_cross_blocks);
   TEST(test_nanots::test_nanots_secondary_key_bidirectional);
   TEST(test_nanots::test_nanots_secondary_key_multi_segment);
-  TEST(test_nanots::test_nanots_secondary_key_unkeyed_stream_rejects_find);
   TEST(test_nanots::test_nanots_secondary_key_mixed_streams_same_file);
   TEST(test_nanots::test_nanots_secondary_key_sparse);
   TEST(test_nanots::test_nanots_secondary_key_extreme_values);
   TEST(test_nanots::test_nanots_secondary_key_reader_callback);
+  TEST(test_nanots::test_nanots_composite_duplicate_timestamps);
+  TEST(test_nanots::test_nanots_composite_find_lands_on_first_at_ts);
   RTF_FIXTURE_END();
 
   virtual ~test_nanots() throw() {}
@@ -95,15 +95,15 @@ class test_nanots : public test_fixture {
   void test_nanots_growable_max_cap();
   void test_nanots_secondary_key_basic();
   void test_nanots_secondary_key_find();
-  void test_nanots_secondary_key_mismatch();
   void test_nanots_secondary_key_monotonic();
   void test_nanots_v1_file_rejected();
   void test_nanots_secondary_key_cross_blocks();
   void test_nanots_secondary_key_bidirectional();
   void test_nanots_secondary_key_multi_segment();
-  void test_nanots_secondary_key_unkeyed_stream_rejects_find();
   void test_nanots_secondary_key_mixed_streams_same_file();
   void test_nanots_secondary_key_sparse();
   void test_nanots_secondary_key_extreme_values();
   void test_nanots_secondary_key_reader_callback();
+  void test_nanots_composite_duplicate_timestamps();
+  void test_nanots_composite_find_lands_on_first_at_ts();
 };

--- a/ut/source/test_nanots.cpp
+++ b/ut/source/test_nanots.cpp
@@ -240,7 +240,7 @@ void test_nanots::test_nanots_reader_time_range() {
   std::vector<std::pair<uint64_t, std::string>> frames_read;
 
   // Read middle portion (1500 to 2200)
-  reader.read("test_stream", 1500, 2200,
+  reader.read("test_stream", 1500, NANOTS_SEC_KEY_UNSET, 2200, INT64_MAX,
               [&](const uint8_t* data, size_t size, uint32_t flags,
                   int64_t timestamp, int64_t /*secondary_key*/,
                   int64_t block_sequence, const std::string& metadata) {
@@ -257,7 +257,7 @@ void test_nanots::test_nanots_reader_time_range() {
 
   // Test reading from beginning
   frames_read.clear();
-  reader.read("test_stream", 0, 1200,
+  reader.read("test_stream", 0, NANOTS_SEC_KEY_UNSET, 1200, INT64_MAX,
               [&](const uint8_t* data, size_t size, uint32_t flags,
                   int64_t timestamp, int64_t /*secondary_key*/,
                   int64_t block_sequence, const std::string& metadata) {
@@ -702,7 +702,7 @@ void test_nanots::test_nanots_metadata_integrity() {
   // Note: This test assumes metadata is accessible during read operations
   // You may need to modify based on your actual metadata access API
 
-  reader.read("video", 0, 2000,
+  reader.read("video", 0, NANOTS_SEC_KEY_UNSET, 2000, INT64_MAX,
               [&](const uint8_t* data, size_t size, uint32_t flags,
                   int64_t timestamp, int64_t /*secondary_key*/,
                   int64_t block_sequence, const std::string& metadata) {
@@ -713,7 +713,7 @@ void test_nanots::test_nanots_metadata_integrity() {
               });
 
   reader.read(
-      "audio", 0, 2000,
+      "audio", 0, NANOTS_SEC_KEY_UNSET, 2000, INT64_MAX,
       [&](const uint8_t* data, size_t size, uint32_t flags, int64_t timestamp,
           int64_t /*secondary_key*/,
                   int64_t block_sequence, const std::string& metadata) { 
@@ -1229,7 +1229,7 @@ void test_nanots::test_nanots_reader_callback_exceptions() {
   bool exception_caught = false;
 
   try {
-    reader.read("exception_stream", 0, 20000,
+    reader.read("exception_stream", 0, NANOTS_SEC_KEY_UNSET, 20000, INT64_MAX,
                 [&](const uint8_t* data, size_t size, uint32_t flags,
                     int64_t timestamp, int64_t /*secondary_key*/,
                   int64_t block_sequence, const std::string& metadata) {
@@ -1440,7 +1440,7 @@ void test_nanots::test_nanots_free_blocks() {
 
   // Delete blocks in the middle time range (5000 to 15000)
   // This should delete frames with timestamps 5000, 6000, 7000, ..., 15000
-  nanots_writer::free_blocks("nanots_test_2048_4k_blocks.nts", "delete_stream", 250, 500);
+  nanots_writer::free_blocks("nanots_test_2048_4k_blocks.nts", "delete_stream", 250, NANOTS_SEC_KEY_UNSET, 500, INT64_MAX);
 
   // Debug: Check what blocks exist after deletion
   debug_result = debug_conn.exec(
@@ -1461,7 +1461,7 @@ void test_nanots::test_nanots_free_blocks() {
   nanots_reader reader("nanots_test_2048_4k_blocks.nts");
   std::vector<uint64_t> remaining_timestamps;
 
-  reader.read("delete_stream", 1, 1024,
+  reader.read("delete_stream", 1, NANOTS_SEC_KEY_UNSET, 1024, INT64_MAX,
               [&](const uint8_t* data, size_t size, uint32_t flags,
                   int64_t timestamp, int64_t /*secondary_key*/,
                   int64_t block_sequence, const std::string& metadata) {
@@ -1503,10 +1503,10 @@ void test_nanots::test_nanots_query_contiguous_segments() {
     }
   }
 
-  nanots_writer::free_blocks("nanots_test_2048_4k_blocks.nts", "test_stream", 250, 500);
+  nanots_writer::free_blocks("nanots_test_2048_4k_blocks.nts", "test_stream", 250, NANOTS_SEC_KEY_UNSET, 500, INT64_MAX);
 
   nanots_reader reader("nanots_test_2048_4k_blocks.nts");
-  auto segments = reader.query_contiguous_segments("test_stream", 1, 1024);
+  auto segments = reader.query_contiguous_segments("test_stream", 1, NANOTS_SEC_KEY_UNSET, 1024, INT64_MAX);
 
   RTF_ASSERT(segments.size() == 2);
   RTF_ASSERT(segments[0].start_timestamp == 1);
@@ -1549,7 +1549,7 @@ void test_nanots::test_nanots_query_stream_tags() {
   // Test query_stream_tags for different time ranges
   
   // Query range that includes all streams (1000-12000)
-  auto all_tags = reader.query_stream_tags(1000, 12000);
+  auto all_tags = reader.query_stream_tags(1000, NANOTS_SEC_KEY_UNSET, 12000, INT64_MAX);
   std::set<std::string> all_tags_set(all_tags.begin(), all_tags.end());
   RTF_ASSERT(all_tags_set.size() == 3);
   RTF_ASSERT(all_tags_set.count("video") == 1);
@@ -1557,7 +1557,7 @@ void test_nanots::test_nanots_query_stream_tags() {
   RTF_ASSERT(all_tags_set.count("metadata") == 1);
 
   // Query range that includes only video and audio (2000-6000)
-  auto video_audio_tags = reader.query_stream_tags(2000, 6000);
+  auto video_audio_tags = reader.query_stream_tags(2000, NANOTS_SEC_KEY_UNSET, 6000, INT64_MAX);
   std::set<std::string> video_audio_set(video_audio_tags.begin(), video_audio_tags.end());
   RTF_ASSERT(video_audio_set.size() == 2);
   RTF_ASSERT(video_audio_set.count("video") == 1);
@@ -1565,7 +1565,7 @@ void test_nanots::test_nanots_query_stream_tags() {
   RTF_ASSERT(video_audio_set.count("metadata") == 0);
 
   // Query range that includes only metadata (8000-12000)
-  auto metadata_tags = reader.query_stream_tags(8000, 12000);
+  auto metadata_tags = reader.query_stream_tags(8000, NANOTS_SEC_KEY_UNSET, 12000, INT64_MAX);
   std::set<std::string> metadata_set(metadata_tags.begin(), metadata_tags.end());
   RTF_ASSERT(metadata_set.size() == 1);
   RTF_ASSERT(metadata_set.count("metadata") == 1);
@@ -1573,11 +1573,11 @@ void test_nanots::test_nanots_query_stream_tags() {
   RTF_ASSERT(metadata_set.count("audio") == 0);
 
   // Query range with no data (20000-25000)
-  auto empty_tags = reader.query_stream_tags(20000, 25000);
+  auto empty_tags = reader.query_stream_tags(20000, NANOTS_SEC_KEY_UNSET, 25000, INT64_MAX);
   RTF_ASSERT(empty_tags.empty());
 
   // Query range that includes only video (1000-1500)
-  auto video_only_tags = reader.query_stream_tags(1000, 1500);
+  auto video_only_tags = reader.query_stream_tags(1000, NANOTS_SEC_KEY_UNSET, 1500, INT64_MAX);
   std::set<std::string> video_only_set(video_only_tags.begin(), video_only_tags.end());
   RTF_ASSERT(video_only_set.size() == 1);
   RTF_ASSERT(video_only_set.count("video") == 1);
@@ -1616,7 +1616,7 @@ void test_nanots::test_nanots_progressive_block_deletion() {
   // Verify initial state - should have 1 contiguous segment
   {
     nanots_reader reader("nanots_test_progressive_deletion.nts");
-    auto segments = reader.query_contiguous_segments("test_stream", start_timestamp, end_timestamp);
+    auto segments = reader.query_contiguous_segments("test_stream", start_timestamp, NANOTS_SEC_KEY_UNSET, end_timestamp, INT64_MAX);
     
     RTF_ASSERT(segments.size() == 1);
     RTF_ASSERT(segments[0].start_timestamp == start_timestamp);
@@ -1633,12 +1633,12 @@ void test_nanots::test_nanots_progressive_block_deletion() {
   
   printf("\nFreeing large window: [%" PRIu64 ", %" PRIu64 "]\n", 
          first_delete_start, first_delete_end);
-  nanots_writer::free_blocks("nanots_test_progressive_deletion.nts", "test_stream", first_delete_start, first_delete_end);
+  nanots_writer::free_blocks("nanots_test_progressive_deletion.nts", "test_stream", first_delete_start, NANOTS_SEC_KEY_UNSET, first_delete_end, INT64_MAX);
   
   // Should now have 2 contiguous segments
   {
     nanots_reader reader("nanots_test_progressive_deletion.nts");
-    auto segments = reader.query_contiguous_segments("test_stream", start_timestamp, end_timestamp);
+    auto segments = reader.query_contiguous_segments("test_stream", start_timestamp, NANOTS_SEC_KEY_UNSET, end_timestamp, INT64_MAX);
     
     RTF_ASSERT(segments.size() == 2);
     RTF_ASSERT(segments[0].start_timestamp == start_timestamp);
@@ -1657,11 +1657,11 @@ void test_nanots::test_nanots_progressive_block_deletion() {
   
   printf("\nFreeing second window: [%" PRIu64 ", %" PRIu64 "]\n", 
          second_delete_start, second_delete_end);
-  nanots_writer::free_blocks("nanots_test_progressive_deletion.nts", "test_stream", second_delete_start, second_delete_end);
+  nanots_writer::free_blocks("nanots_test_progressive_deletion.nts", "test_stream", second_delete_start, NANOTS_SEC_KEY_UNSET, second_delete_end, INT64_MAX);
   
   {
     nanots_reader reader("nanots_test_progressive_deletion.nts");
-    auto segments = reader.query_contiguous_segments("test_stream", start_timestamp, end_timestamp);
+    auto segments = reader.query_contiguous_segments("test_stream", start_timestamp, NANOTS_SEC_KEY_UNSET, end_timestamp, INT64_MAX);
     
     // Should have at least 2 segments, possibly 3 if the windows don't overlap
     RTF_ASSERT(segments.size() >= 2);
@@ -1679,11 +1679,11 @@ void test_nanots::test_nanots_progressive_block_deletion() {
   
   printf("\nFreeing third window: [%" PRIu64 ", %" PRIu64 "]\n", 
          third_delete_start, third_delete_end);
-  nanots_writer::free_blocks("nanots_test_progressive_deletion.nts", "test_stream", third_delete_start, third_delete_end);
+  nanots_writer::free_blocks("nanots_test_progressive_deletion.nts", "test_stream", third_delete_start, NANOTS_SEC_KEY_UNSET, third_delete_end, INT64_MAX);
   
   {
     nanots_reader reader("nanots_test_progressive_deletion.nts");
-    auto segments = reader.query_contiguous_segments("test_stream", start_timestamp, end_timestamp);
+    auto segments = reader.query_contiguous_segments("test_stream", start_timestamp, NANOTS_SEC_KEY_UNSET, end_timestamp, INT64_MAX);
     
     // Should have multiple segments now
     RTF_ASSERT(segments.size() >= 2);
@@ -1705,14 +1705,14 @@ void test_nanots::test_nanots_progressive_block_deletion() {
   
   // Get current segment count
   nanots_reader reader_before("nanots_test_progressive_deletion.nts");
-  auto segments_before = reader_before.query_contiguous_segments("test_stream", start_timestamp, end_timestamp);
+  auto segments_before = reader_before.query_contiguous_segments("test_stream", start_timestamp, NANOTS_SEC_KEY_UNSET, end_timestamp, INT64_MAX);
   size_t count_before = segments_before.size();
   
-  nanots_writer::free_blocks("nanots_test_progressive_deletion.nts", "test_stream", tiny_start, tiny_end);
+  nanots_writer::free_blocks("nanots_test_progressive_deletion.nts", "test_stream", tiny_start, NANOTS_SEC_KEY_UNSET, tiny_end, INT64_MAX);
   
   // Check that segment count hasn't changed
   nanots_reader reader_after("nanots_test_progressive_deletion.nts");
-  auto segments_after = reader_after.query_contiguous_segments("test_stream", start_timestamp, end_timestamp);
+  auto segments_after = reader_after.query_contiguous_segments("test_stream", start_timestamp, NANOTS_SEC_KEY_UNSET, end_timestamp, INT64_MAX);
   
   RTF_ASSERT(segments_after.size() == count_before);
   printf("After tiny range free attempt: still %zu contiguous segment(s) (unchanged)\n", segments_after.size());
@@ -1720,7 +1720,7 @@ void test_nanots::test_nanots_progressive_block_deletion() {
   // Test querying a deleted range
   {
     nanots_reader reader("nanots_test_progressive_deletion.nts");
-    auto segments = reader.query_contiguous_segments("test_stream", first_delete_start, first_delete_end);
+    auto segments = reader.query_contiguous_segments("test_stream", first_delete_start, NANOTS_SEC_KEY_UNSET, first_delete_end, INT64_MAX);
     
     // Should return empty or very few segments since most of this range was deleted
     printf("\nQuery in first deleted range [%" PRIu64 ", %" PRIu64 "]: %zu segment(s)\n", 
@@ -2210,7 +2210,7 @@ void test_nanots::test_nanots_secondary_key_basic() {
   // Reader callback round-trip.
   nanots_reader reader("nanots_test_4mb.nts");
   int j = 0;
-  reader.read("sk_stream", 0, 100000,
+  reader.read("sk_stream", 0, NANOTS_SEC_KEY_UNSET, 100000, INT64_MAX,
               [&](const uint8_t* data, size_t size, uint32_t flags,
                   int64_t timestamp, int64_t sec_key,
                   int64_t block_seq, const std::string& meta) {
@@ -2671,7 +2671,7 @@ void test_nanots::test_nanots_secondary_key_reader_callback() {
 
   // Keyed: every callback should see the right sec_key.
   std::vector<int64_t> seen_keyed;
-  reader.read("rk_keyed", 0, 100000,
+  reader.read("rk_keyed", 0, NANOTS_SEC_KEY_UNSET, 100000, INT64_MAX,
               [&](const uint8_t* data, size_t size, uint32_t flags,
                   int64_t ts, int64_t sk,
                   int64_t block_seq, const std::string& meta) {
@@ -2684,7 +2684,7 @@ void test_nanots::test_nanots_secondary_key_reader_callback() {
 
   // Unkeyed: every callback should see NANOTS_SEC_KEY_UNSET.
   std::vector<int64_t> seen_unkeyed;
-  reader.read("rk_unkeyed", 0, 100000,
+  reader.read("rk_unkeyed", 0, NANOTS_SEC_KEY_UNSET, 100000, INT64_MAX,
               [&](const uint8_t* data, size_t size, uint32_t flags,
                   int64_t ts, int64_t sk,
                   int64_t block_seq, const std::string& meta) {

--- a/ut/source/test_nanots.cpp
+++ b/ut/source/test_nanots.cpp
@@ -58,12 +58,12 @@ void test_nanots::test_nanots_basic() {
   {
     auto wctx = db.create_write_context("test_stream", "test metadata");
 
-    db.write(wctx, (uint8_t*)frame1_data.c_str(), (uint32_t)frame1_data.size(),
-             1000, 0x01);
-    db.write(wctx, (uint8_t*)frame2_data.c_str(), (uint32_t)frame2_data.size(),
-             2000, 0x02);
-    db.write(wctx, (uint8_t*)frame3_data.c_str(), (uint32_t)frame3_data.size(),
-             3000, 0x03);
+    db.write(wctx, (uint8_t*)frame1_data.c_str(), (uint32_t)frame1_data.size(), 0x01,
+             1000);
+    db.write(wctx, (uint8_t*)frame2_data.c_str(), (uint32_t)frame2_data.size(), 0x02,
+             2000);
+    db.write(wctx, (uint8_t*)frame3_data.c_str(), (uint32_t)frame3_data.size(), 0x03,
+             3000);
   }
 
   // Read back using iterator
@@ -112,8 +112,8 @@ void test_nanots::test_nanots_iterator_find() {
     for (int i = 0; i < 10; i++) {
       std::string data = "frame_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 500);  // 1000, 1500, 2000, 2500, ...
-      db.write(wctx, (uint8_t*)data.c_str(), (uint32_t)data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), (uint32_t)data.size(),
+               (uint8_t)i, timestamp);
     }
 
     auto after = std::chrono::steady_clock::now();
@@ -163,11 +163,11 @@ void test_nanots::test_nanots_multiple_streams() {
       std::string meta_data = "sensor_" + std::to_string(i);
 
       db.write(video_ctx, (uint8_t*)video_data.c_str(),
-               (uint32_t)video_data.size(), base_timestamp, 0x01);
+               (uint32_t)video_data.size(), 0x01, base_timestamp);
       db.write(audio_ctx, (uint8_t*)audio_data.c_str(),
-               (uint32_t)audio_data.size(), base_timestamp + 10, 0x02);
+               (uint32_t)audio_data.size(), 0x02, base_timestamp + 10);
       db.write(metadata_ctx, (uint8_t*)meta_data.c_str(),
-               (uint32_t)meta_data.size(), base_timestamp + 20, 0x03);
+               (uint32_t)meta_data.size(), 0x03, base_timestamp + 20);
     }
   }
 
@@ -229,8 +229,8 @@ void test_nanots::test_nanots_reader_time_range() {
     for (int i = 0; i < 20; i++) {
       std::string data = "frame_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 100);  // 1000 to 2900
-      db.write(wctx, (uint8_t*)data.c_str(), (uint32_t)data.size(), timestamp,
-               (uint8_t)(i % 256));
+      db.write(wctx, (uint8_t*)data.c_str(), (uint32_t)data.size(),
+               (uint8_t)(i % 256), timestamp);
     }
   }
 
@@ -241,8 +241,9 @@ void test_nanots::test_nanots_reader_time_range() {
 
   // Read middle portion (1500 to 2200)
   reader.read("test_stream", 1500, 2200,
-              [&](const uint8_t* data, size_t size, uint8_t flags,
-                  uint64_t timestamp, uint64_t block_sequence, const std::string& metadata) {
+              [&](const uint8_t* data, size_t size, uint32_t flags,
+                  int64_t timestamp, int64_t /*secondary_key*/,
+                  int64_t block_sequence, const std::string& metadata) {
                 std::string frame_data((char*)data, size);
                 frames_read.push_back({timestamp, frame_data});
               });
@@ -257,8 +258,9 @@ void test_nanots::test_nanots_reader_time_range() {
   // Test reading from beginning
   frames_read.clear();
   reader.read("test_stream", 0, 1200,
-              [&](const uint8_t* data, size_t size, uint8_t flags,
-                  uint64_t timestamp, uint64_t block_sequence, const std::string& metadata) {
+              [&](const uint8_t* data, size_t size, uint32_t flags,
+                  int64_t timestamp, int64_t /*secondary_key*/,
+                  int64_t block_sequence, const std::string& metadata) {
                 std::string frame_data((char*)data, size);
                 frames_read.push_back({timestamp, frame_data});
               });
@@ -277,8 +279,8 @@ void test_nanots::test_nanots_iterator_bidirectional() {
     for (int i = 0; i < 10; i++) {
       std::string data = "data_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 1000);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
   }
 
@@ -327,7 +329,7 @@ void test_nanots::test_nanots_large_frames() {
       }
 
       uint64_t timestamp = 1000 + (i * 1000);
-      db.write(wctx, large_data.data(), frame_size, timestamp, (uint8_t)i);
+      db.write(wctx, large_data.data(), frame_size, (uint8_t)i, timestamp);
     }
   }
 
@@ -367,7 +369,7 @@ void test_nanots::test_nanots_edge_cases() {
   {
     auto wctx = db.create_write_context("single_stream", "single frame test");
     std::string data = "single_frame";
-    db.write(wctx, (uint8_t*)data.c_str(), data.size(), 1000, 0x01);
+    db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0x01, 1000);
   }
 
   {
@@ -381,7 +383,7 @@ void test_nanots::test_nanots_edge_cases() {
   // Test zero-sized frame (if allowed)
   {
     auto wctx = db.create_write_context("zero_stream", "zero size test");
-    db.write(wctx, nullptr, 0, 2000, 0x00);
+    db.write(wctx, nullptr, 0, 0x00, 2000);
   }
 
   {
@@ -402,7 +404,7 @@ void test_nanots::test_nanots_cross_segment_iteration() {
     for (int i = 0; i < 5; i++) {
       std::string data = "seg1_frame_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 100);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp, 0x01);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0x01, timestamp);
     }
   }
 
@@ -412,7 +414,7 @@ void test_nanots::test_nanots_cross_segment_iteration() {
     for (int i = 0; i < 5; i++) {
       std::string data = "seg2_frame_" + std::to_string(i);
       uint64_t timestamp = 2000 + (i * 100);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp, 0x02);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0x02, timestamp);
     }
   }
 
@@ -422,7 +424,7 @@ void test_nanots::test_nanots_cross_segment_iteration() {
     for (int i = 0; i < 5; i++) {
       std::string data = "seg3_frame_" + std::to_string(i);
       uint64_t timestamp = 3000 + (i * 100);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp, 0x03);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0x03, timestamp);
     }
   }
 
@@ -537,15 +539,15 @@ void test_nanots::test_nanots_monotonic_timestamp_validation() {
   std::string data3 = "frame3";
 
   // Write first frame
-  db.write(wctx, (uint8_t*)data1.c_str(), data1.size(), 1000, 0x01);
+  db.write(wctx, (uint8_t*)data1.c_str(), data1.size(), 0x01, 1000);
 
   // Write second frame with higher timestamp (should succeed)
-  db.write(wctx, (uint8_t*)data2.c_str(), data2.size(), 2000, 0x02);
+  db.write(wctx, (uint8_t*)data2.c_str(), data2.size(), 0x02, 2000);
 
   // Try to write with equal timestamp (should throw)
   bool caught_exception = false;
   try {
-    db.write(wctx, (uint8_t*)data3.c_str(), data3.size(), 2000, 0x03);
+    db.write(wctx, (uint8_t*)data3.c_str(), data3.size(), 0x03, 2000);
   } catch (const std::exception&) {
     caught_exception = true;
   }
@@ -554,14 +556,14 @@ void test_nanots::test_nanots_monotonic_timestamp_validation() {
   // Try to write with lower timestamp (should throw)
   caught_exception = false;
   try {
-    db.write(wctx, (uint8_t*)data3.c_str(), data3.size(), 1500, 0x03);
+    db.write(wctx, (uint8_t*)data3.c_str(), data3.size(), 0x03, 1500);
   } catch (const std::exception&) {
     caught_exception = true;
   }
   RTF_ASSERT(caught_exception);
 
   // Write with higher timestamp (should succeed)
-  db.write(wctx, (uint8_t*)data3.c_str(), data3.size(), 3000, 0x03);
+  db.write(wctx, (uint8_t*)data3.c_str(), data3.size(), 0x03, 3000);
 
   // Verify only valid frames are present
   nanots_iterator iter("nanots_test_4mb.nts", "test_stream");
@@ -591,8 +593,8 @@ void test_nanots::test_nanots_performance_baseline() {
 
     for (int i = 0; i < num_frames; i++) {
       uint64_t timestamp = 1000 + i;
-      db.write(wctx, test_data.data(), frame_size, timestamp,
-               (uint8_t)(i % 256));
+      db.write(wctx, test_data.data(), frame_size,
+               (uint8_t)(i % 256), timestamp);
     }
   }
 
@@ -643,8 +645,8 @@ void test_nanots::test_nanots_concurrent_readers() {
     for (int i = 0; i < 100; i++) {
       std::string data = "concurrent_frame_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 100);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)(i % 256));
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)(i % 256), timestamp);
     }
   }
 
@@ -686,8 +688,8 @@ void test_nanots::test_nanots_metadata_integrity() {
     auto video_ctx = db.create_write_context("video", video_metadata);
     auto audio_ctx = db.create_write_context("audio", audio_metadata);
 
-    db.write(video_ctx, (uint8_t*)"video1", 6, 1000, 0x01);
-    db.write(audio_ctx, (uint8_t*)"audio1", 6, 1010, 0x02);
+    db.write(video_ctx, (uint8_t*)"video1", 6, 0x01, 1000);
+    db.write(audio_ctx, (uint8_t*)"audio1", 6, 0x02, 1010);
   }
 
   // Verify metadata is preserved during reads
@@ -701,8 +703,9 @@ void test_nanots::test_nanots_metadata_integrity() {
   // You may need to modify based on your actual metadata access API
 
   reader.read("video", 0, 2000,
-              [&](const uint8_t* data, size_t size, uint8_t flags,
-                  uint64_t timestamp, uint64_t block_sequence, const std::string& metadata) {
+              [&](const uint8_t* data, size_t size, uint32_t flags,
+                  int64_t timestamp, int64_t /*secondary_key*/,
+                  int64_t block_sequence, const std::string& metadata) {
                 // Now we can actually verify the metadata
                 if (metadata == "codec=h264,resolution=1920x1080,fps=30") {
                   video_metadata_correct = true;
@@ -711,8 +714,9 @@ void test_nanots::test_nanots_metadata_integrity() {
 
   reader.read(
       "audio", 0, 2000,
-      [&](const uint8_t* data, size_t size, uint8_t flags, uint64_t timestamp,
-          uint64_t block_sequence, const std::string& metadata) { 
+      [&](const uint8_t* data, size_t size, uint32_t flags, int64_t timestamp,
+          int64_t /*secondary_key*/,
+                  int64_t block_sequence, const std::string& metadata) { 
             if (metadata == "codec=aac,samplerate=44100,channels=2") {
               audio_metadata_correct = true;
             }
@@ -741,8 +745,8 @@ void test_nanots::test_nanots_block_exhaustion() {
     for (int i = 0; i < 100 && !write_failed; i++) {
       try {
         uint64_t timestamp = 1000 + (i * 1000);
-        db.write(wctx, large_data.data(), large_frame_size, timestamp,
-                 (uint8_t)i);
+        db.write(wctx, large_data.data(), large_frame_size,
+                 (uint8_t)i, timestamp);
         successful_writes++;
       } catch (const std::exception&) {
         printf("Write failed after %d frames.\n", successful_writes);
@@ -793,8 +797,8 @@ void test_nanots::test_nanots_block_filling_and_transition() {
     // Write enough to trigger at least one block transition
     for (int i = 0; i < 20; i++) {  // Reduced count to avoid exhausting blocks
       uint64_t timestamp = 1000 + (i * 1000);
-      db.write(wctx, large_data.data(), large_frame_size, timestamp,
-               (uint8_t)(i % 256));
+      db.write(wctx, large_data.data(), large_frame_size,
+               (uint8_t)(i % 256), timestamp);
       frames_written++;
     }
 
@@ -852,8 +856,8 @@ void test_nanots::test_nanots_sparse_timestamp_seeking() {
 
     for (size_t i = 0; i < timestamps.size(); i++) {
       std::string data = "sparse_frame_" + std::to_string(i);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamps[i],
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamps[i]);
     }
   }
 
@@ -906,8 +910,8 @@ void test_nanots::test_nanots_write_context_lifecycle() {
       std::string data = "batch1_frame_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 1000);
       printf("Writing frame %s\n", data.c_str());
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
 
     // Write second batch (continuing same context - proper way)
@@ -915,8 +919,8 @@ void test_nanots::test_nanots_write_context_lifecycle() {
       std::string data = "batch2_frame_" + std::to_string(i);
       uint64_t timestamp = 10000 + (i * 1000);
       printf("Writing frame %s\n", data.c_str());
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
 
     // Write third batch (continuing same context)
@@ -924,8 +928,8 @@ void test_nanots::test_nanots_write_context_lifecycle() {
       std::string data = "batch3_frame_" + std::to_string(i);
       uint64_t timestamp = 20000 + (i * 1000);
       printf("Writing frame %s\n", data.c_str());
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
     // wctx destructor will finalize the final block
   }
@@ -975,12 +979,12 @@ void test_nanots::test_nanots_multiple_streams_separate_writers() {
       std::string audio_data = "audio_" + std::to_string(i);
       std::string sensor_data = "sensor_" + std::to_string(i);
 
-      db.write(video_ctx, (uint8_t*)video_data.c_str(), video_data.size(),
-               base_timestamp, 0x01);
-      db.write(audio_ctx, (uint8_t*)audio_data.c_str(), audio_data.size(),
-               base_timestamp + 10, 0x02);
-      db.write(data_ctx, (uint8_t*)sensor_data.c_str(), sensor_data.size(),
-               base_timestamp + 20, 0x03);
+      db.write(video_ctx, (uint8_t*)video_data.c_str(), video_data.size(), 0x01,
+               base_timestamp);
+      db.write(audio_ctx, (uint8_t*)audio_data.c_str(), audio_data.size(), 0x02,
+               base_timestamp + 10);
+      db.write(data_ctx, (uint8_t*)sensor_data.c_str(), sensor_data.size(), 0x03,
+               base_timestamp + 20);
     }
   }
 
@@ -1012,7 +1016,7 @@ void test_nanots::test_nanots_invalid_multiple_writers_same_stream() {
   nanots_writer db("nanots_test_4mb.nts", false);
   
   auto ctx1 = db.create_write_context("shared_stream", "first writer");
-  db.write(ctx1, (uint8_t*)"frame1", 6, 1000, 0x01);
+  db.write(ctx1, (uint8_t*)"frame1", 6, 0x01, 1000);
 
   bool second_writer_threw = false;
   nanots_ec_t ec = NANOTS_EC_OK;
@@ -1045,8 +1049,8 @@ void test_nanots::test_nanots_multiple_segments_same_stream() {
       std::string data = "reuse_data_batch1_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 1000);
       printf("Writing frame %s\n", data.c_str());
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
 
     // Write second batch (continuing same context)
@@ -1054,8 +1058,8 @@ void test_nanots::test_nanots_multiple_segments_same_stream() {
       std::string data = "reuse_data_batch2_" + std::to_string(i);
       uint64_t timestamp = 10000 + (i * 1000);
       printf("Writing frame %s\n", data.c_str());
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
 
     // Write third batch (continuing same context)
@@ -1063,8 +1067,8 @@ void test_nanots::test_nanots_multiple_segments_same_stream() {
       std::string data = "reuse_data_batch3_" + std::to_string(i);
       uint64_t timestamp = 20000 + (i * 1000);
       printf("Writing frame %s\n", data.c_str());
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
     // wctx destructor will finalize the final block
   }
@@ -1102,8 +1106,8 @@ void test_nanots::test_nanots_iterator_edge_navigation() {
     for (int i = 0; i < 10; i++) {
       std::string data = "edge_frame_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 1000);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
   }
 
@@ -1173,7 +1177,7 @@ void test_nanots::test_nanots_mixed_frame_sizes() {
       }
 
       uint64_t timestamp = 1000 + (i * 1000);
-      db.write(wctx, data.data(), size, timestamp, (uint8_t)i);
+      db.write(wctx, data.data(), size, (uint8_t)i, timestamp);
     }
   }
 
@@ -1213,8 +1217,8 @@ void test_nanots::test_nanots_reader_callback_exceptions() {
     for (int i = 0; i < 10; i++) {
       std::string data = "exception_frame_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 1000);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), timestamp,
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, timestamp);
     }
   }
 
@@ -1226,8 +1230,9 @@ void test_nanots::test_nanots_reader_callback_exceptions() {
 
   try {
     reader.read("exception_stream", 0, 20000,
-                [&](const uint8_t* data, size_t size, uint8_t flags,
-                    uint64_t timestamp, uint64_t block_sequence, const std::string& metadata) {
+                [&](const uint8_t* data, size_t size, uint32_t flags,
+                    int64_t timestamp, int64_t /*secondary_key*/,
+                  int64_t block_sequence, const std::string& metadata) {
                   frames_processed++;
 
                   if (frames_processed == 5) {
@@ -1273,8 +1278,8 @@ void test_nanots::test_nanots_high_frequency_writes() {
     for (int i = 0; i < num_frames; i++) {
       // Microsecond precision timestamps
       uint64_t timestamp = 1000000 + i;  // 1 microsecond apart
-      db.write(wctx, test_data.data(), frame_size, timestamp,
-               (uint8_t)(i % 256));
+      db.write(wctx, test_data.data(), frame_size,
+               (uint8_t)(i % 256), timestamp);
     }
   }
 
@@ -1339,8 +1344,8 @@ void test_nanots::test_nanots_timestamp_precision() {
 
     for (size_t i = 0; i < precise_timestamps.size(); i++) {
       std::string data = "precise_" + std::to_string(i);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), precise_timestamps[i],
-               (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(),
+               (uint8_t)i, precise_timestamps[i]);
     }
   }
 
@@ -1401,7 +1406,7 @@ void test_nanots::test_nanots_free_blocks() {
     std::vector<uint8_t> one_k_row(1024);
 
     for (int i = 1; i < 1024; i++) {
-      db.write(wctx, one_k_row.data(), one_k_row.size(), i, (uint8_t)i);
+      db.write(wctx, one_k_row.data(), one_k_row.size(), (uint8_t)i, i);
     }
   }
 
@@ -1457,8 +1462,9 @@ void test_nanots::test_nanots_free_blocks() {
   std::vector<uint64_t> remaining_timestamps;
 
   reader.read("delete_stream", 1, 1024,
-              [&](const uint8_t* data, size_t size, uint8_t flags,
-                  uint64_t timestamp, uint64_t block_sequence, const std::string& metadata) {
+              [&](const uint8_t* data, size_t size, uint32_t flags,
+                  int64_t timestamp, int64_t /*secondary_key*/,
+                  int64_t block_sequence, const std::string& metadata) {
                 remaining_timestamps.push_back(timestamp);
               });
 
@@ -1493,7 +1499,7 @@ void test_nanots::test_nanots_query_contiguous_segments() {
     auto wctx = db.create_write_context("test_stream", "meta");
     std::vector<uint8_t> one_k_row(1024);
     for (int i = 1; i < 1024; i++) {
-      db.write(wctx, one_k_row.data(), one_k_row.size(), i, (uint8_t)i);
+      db.write(wctx, one_k_row.data(), one_k_row.size(), (uint8_t)i, i);
     }
   }
 
@@ -1520,21 +1526,21 @@ void test_nanots::test_nanots_query_stream_tags() {
     for (int i = 0; i < 5; i++) {
       std::string data = "video_frame_" + std::to_string(i);
       uint64_t timestamp = 1000 + (i * 1000);
-      db.write(video_ctx, (uint8_t*)data.c_str(), data.size(), timestamp, 0x01);
+      db.write(video_ctx, (uint8_t*)data.c_str(), data.size(), 0x01, timestamp);
     }
 
     // Write audio samples: 2000-6000 (overlaps with video)
     for (int i = 0; i < 5; i++) {
       std::string data = "audio_sample_" + std::to_string(i);
       uint64_t timestamp = 2000 + (i * 1000);
-      db.write(audio_ctx, (uint8_t*)data.c_str(), data.size(), timestamp, 0x02);
+      db.write(audio_ctx, (uint8_t*)data.c_str(), data.size(), 0x02, timestamp);
     }
 
     // Write metadata: 8000-12000 (non-overlapping)
     for (int i = 0; i < 5; i++) {
       std::string data = "sensor_" + std::to_string(i);
       uint64_t timestamp = 8000 + (i * 1000);
-      db.write(metadata_ctx, (uint8_t*)data.c_str(), data.size(), timestamp, 0x03);
+      db.write(metadata_ctx, (uint8_t*)data.c_str(), data.size(), 0x03, timestamp);
     }
   }
 
@@ -1603,7 +1609,7 @@ void test_nanots::test_nanots_progressive_block_deletion() {
     // Write frames with sequential timestamps starting at 10000
     for (int i = 0; i < total_frames; i++) {
       uint64_t timestamp = start_timestamp + i * 10;  // Space timestamps by 10
-      db.write(wctx, frame_data.data(), frame_size, timestamp, (uint8_t)(i % 256));
+      db.write(wctx, frame_data.data(), frame_size, (uint8_t)(i % 256), timestamp);
     }
   }
   
@@ -1745,14 +1751,14 @@ void test_nanots::test_nanots_iterator_block_transition_flag_search() {
       
       // Every 20th row has flags = 1, others have flags = 0
       // But skip the flagged frame at the block boundary to force cross-block search
-      uint8_t flags = (i % 20 == 0 && i != 120) ? 1 : 0;
+      uint32_t flags = (i % 20 == 0 && i != 120) ? 1 : 0;
       
       // Fill frame with unique pattern to verify integrity
       for (size_t j = 0; j < frame_size; j++) {
         frame_data[j] = (uint8_t)((i + j) % 256);
       }
       
-      db.write(wctx, frame_data.data(), frame_size, timestamp, flags);
+      db.write(wctx, frame_data.data(), frame_size, flags, timestamp);
       
       if (flags == 1) {
         printf("  Wrote flagged frame %d at timestamp %" PRIu64 "\n", i, timestamp);
@@ -1826,7 +1832,7 @@ void test_nanots::test_nanots_iterator_block_transition_flag_search() {
          iter->timestamp);
   
   while (iter.valid()) {
-    printf("  Step %d: timestamp=%" PRId64 ", flags=%d, block_sequence=%" PRId64 "\n", 
+    printf("  Step %d: timestamp=%" PRId64 ", flags=%u, block_sequence=%" PRId64 "\n",
            steps_backward, iter->timestamp, iter->flags, iter->block_sequence);
     
     if (iter->flags == 1) {
@@ -1882,14 +1888,14 @@ void test_nanots::test_nanots_iterator_performance_benchmark() {
     
     for (int i = 0; i < num_rows; i++) {
       uint64_t timestamp = start_timestamp + i;
-      uint8_t flags = (i % 30 == 0) ? 1 : 0;
+      uint32_t flags = (i % 30 == 0) ? 1 : 0;
       
       // Fill row with pattern for verification
       for (size_t j = 0; j < row_size; j++) {
         row_data[j] = (uint8_t)((i + j) % 256);
       }
       
-      db.write(wctx, row_data.data(), row_size, timestamp, flags);
+      db.write(wctx, row_data.data(), row_size, flags, timestamp);
     }
   }
   
@@ -1968,7 +1974,7 @@ void test_nanots::test_nanots_iterator_seek_end() {
     auto wctx = db.create_write_context("seek_end_stream", "seek_end test");
     for (int i = 0; i < 10; i++) {
       std::string data = "frame_" + std::to_string(i);
-      db.write(wctx, (uint8_t*)data.c_str(), data.size(), 1000 + i * 100, (uint8_t)i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(), (uint8_t)i, 1000 + i * 100);
     }
   }
 
@@ -2002,7 +2008,7 @@ void test_nanots::test_nanots_iterator_seek_end() {
       auto wctx = db.create_write_context("seek_end_multi", "segment 1");
       for (int i = 0; i < 5; i++) {
         std::string data = "seg1_" + std::to_string(i);
-        db.write(wctx, (uint8_t*)data.c_str(), data.size(), 1000 + i * 100, 0x01);
+        db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0x01, 1000 + i * 100);
       }
     }
 
@@ -2010,7 +2016,7 @@ void test_nanots::test_nanots_iterator_seek_end() {
       auto wctx = db.create_write_context("seek_end_multi", "segment 2");
       for (int i = 0; i < 5; i++) {
         std::string data = "seg2_" + std::to_string(i);
-        db.write(wctx, (uint8_t*)data.c_str(), data.size(), 2000 + i * 100, 0x02);
+        db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0x02, 2000 + i * 100);
       }
     }
 
@@ -2018,7 +2024,7 @@ void test_nanots::test_nanots_iterator_seek_end() {
       auto wctx = db.create_write_context("seek_end_multi", "segment 3");
       for (int i = 0; i < 5; i++) {
         std::string data = "seg3_" + std::to_string(i);
-        db.write(wctx, (uint8_t*)data.c_str(), data.size(), 3000 + i * 100, 0x03);
+        db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0x03, 3000 + i * 100);
       }
     }
   }
@@ -2067,7 +2073,7 @@ void test_nanots::test_nanots_growable_basic() {
     std::vector<uint8_t> data(frame_size, 0x5A);
 
     for (int i = 0; i < 200; i++) {
-      db.write(wctx, data.data(), frame_size, 1000 + i * 100, (uint8_t)(i & 0xff));
+      db.write(wctx, data.data(), frame_size, (uint8_t)(i & 0xff), 1000 + i * 100);
     }
   }
 
@@ -2114,7 +2120,7 @@ void test_nanots::test_nanots_growable_doubling() {
   std::vector<uint64_t> sizes;
   sizes.push_back(file_size(nts));
   for (int i = 0; i < 8; i++) {
-    db.write(wctx, data.data(), frame_size, 1000 + i, 0);
+    db.write(wctx, data.data(), frame_size, 0, 1000 + i);
     sizes.push_back(file_size(nts));
   }
 
@@ -2154,7 +2160,7 @@ void test_nanots::test_nanots_growable_max_cap() {
   bool threw = false;
   for (int i = 0; i < 20 && !threw; i++) {
     try {
-      db.write(wctx, data.data(), frame_size, 1000 + i, 0);
+      db.write(wctx, data.data(), frame_size, 0, 1000 + i);
       wrote++;
     } catch (const nanots_exception& e) {
       RTF_ASSERT(e.get_ec() == NANOTS_EC_NO_FREE_BLOCKS);
@@ -2171,4 +2177,592 @@ void test_nanots::test_nanots_growable_max_cap() {
 
   uint64_t final_size = file_size(nts);
   RTF_ASSERT(final_size == 64 * 1024 + (uint64_t)cap * block_size);
+}
+
+// --- Secondary key tests --------------------------------------------------
+
+// Basic: write frames with a secondary key, read them back, verify the key
+// round-trips through both the iterator and the reader.
+void test_nanots::test_nanots_secondary_key_basic() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+
+  {
+    auto wctx = db.create_write_context("sk_stream", "secondary key test");
+    for (int i = 0; i < 10; i++) {
+      std::string data = "frame_" + std::to_string(i);
+      // sec_key advances by 7 each frame, distinct from timestamp pattern.
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0x01,
+               1000 + i * 100, /*sec_key=*/100 + i * 7);
+    }
+  }
+
+  // Iterator round-trip.
+  nanots_iterator iter("nanots_test_4mb.nts", "sk_stream");
+  RTF_ASSERT(iter.has_secondary_key());
+  int i = 0;
+  while (iter.valid()) {
+    RTF_ASSERT(iter->timestamp == 1000 + i * 100);
+    RTF_ASSERT(iter->secondary_key == 100 + i * 7);
+    ++iter;
+    i++;
+  }
+  RTF_ASSERT(i == 10);
+
+  // Reader callback round-trip.
+  nanots_reader reader("nanots_test_4mb.nts");
+  int j = 0;
+  reader.read("sk_stream", 0, 100000,
+              [&](const uint8_t* data, size_t size, uint32_t flags,
+                  int64_t timestamp, int64_t sec_key,
+                  int64_t block_seq, const std::string& meta) {
+                RTF_ASSERT(timestamp == 1000 + j * 100);
+                RTF_ASSERT(sec_key == 100 + j * 7);
+                j++;
+              });
+  RTF_ASSERT(j == 10);
+}
+
+// Verify find_by_secondary_key works the same way find(timestamp) does:
+// exact match, between-keys lands on next-higher, before-first lands on
+// first, after-last invalidates.
+void test_nanots::test_nanots_secondary_key_find() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+
+  {
+    auto wctx = db.create_write_context("sk_find", "");
+    for (int i = 0; i < 10; i++) {
+      std::string data = "sk_" + std::to_string(i);
+      db.write(wctx, (uint8_t*)data.c_str(), data.size(), 0,
+               1000 + i * 100, /*sec_key=*/1000 + i * 500);
+    }
+  }
+
+  nanots_iterator iter("nanots_test_4mb.nts", "sk_find");
+  RTF_ASSERT(iter.has_secondary_key());
+
+  // Exact match.
+  RTF_ASSERT(iter.find_by_secondary_key(2000));
+  RTF_ASSERT(iter->secondary_key == 2000);
+
+  // Between keys → next higher.
+  RTF_ASSERT(iter.find_by_secondary_key(2250));
+  RTF_ASSERT(iter->secondary_key == 2500);
+
+  // Before first.
+  RTF_ASSERT(iter.find_by_secondary_key(0));
+  RTF_ASSERT(iter->secondary_key == 1000);
+
+  // Past last.
+  RTF_ASSERT(!iter.find_by_secondary_key(100000));
+  RTF_ASSERT(!iter.valid());
+}
+
+// Mixing keyed and unkeyed writes on the same stream is rejected.
+void test_nanots::test_nanots_secondary_key_mismatch() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+
+  // Case 1: stream is locked as "keyed" on first write; later unkeyed write
+  // throws.
+  {
+    auto wctx = db.create_write_context("sk_mismatch_a", "");
+    db.write(wctx, (uint8_t*)"a", 1, 0, 1000, /*sec_key=*/42);
+
+    bool threw = false;
+    nanots_ec_t ec = NANOTS_EC_OK;
+    try {
+      db.write(wctx, (uint8_t*)"b", 1, 0, 1100);
+    } catch (const nanots_exception& e) {
+      threw = true;
+      ec = e.get_ec();
+    }
+    RTF_ASSERT(threw);
+    RTF_ASSERT(ec == NANOTS_EC_SECONDARY_KEY_MISMATCH);
+  }
+
+  // Case 2: stream locked as "unkeyed"; later keyed write throws.
+  {
+    auto wctx = db.create_write_context("sk_mismatch_b", "");
+    db.write(wctx, (uint8_t*)"a", 1, 0, 1000);
+
+    bool threw = false;
+    nanots_ec_t ec = NANOTS_EC_OK;
+    try {
+      db.write(wctx, (uint8_t*)"b", 1, 0, 1100, /*sec_key=*/99);
+    } catch (const nanots_exception& e) {
+      threw = true;
+      ec = e.get_ec();
+    }
+    RTF_ASSERT(threw);
+    RTF_ASSERT(ec == NANOTS_EC_SECONDARY_KEY_MISMATCH);
+  }
+
+  // Case 3: a new write_context on a previously-keyed stream must continue
+  // to be keyed; passing UNSET in the first write of the new context throws.
+  {
+    {
+      auto wctx = db.create_write_context("sk_mismatch_c", "");
+      db.write(wctx, (uint8_t*)"a", 1, 0, 1000, /*sec_key=*/1);
+    }
+    auto wctx2 = db.create_write_context("sk_mismatch_c", "");
+    bool threw = false;
+    try {
+      db.write(wctx2, (uint8_t*)"b", 1, 0, 2000);
+    } catch (const nanots_exception& e) {
+      threw = true;
+      RTF_ASSERT(e.get_ec() == NANOTS_EC_SECONDARY_KEY_MISMATCH);
+    }
+    RTF_ASSERT(threw);
+  }
+}
+
+// Secondary key must be monotonic within a write context, same rule as
+// timestamps.
+void test_nanots::test_nanots_secondary_key_monotonic() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+  auto wctx = db.create_write_context("sk_mono", "");
+
+  db.write(wctx, (uint8_t*)"a", 1, 0, 1000, /*sec_key=*/100);
+  db.write(wctx, (uint8_t*)"b", 1, 0, 2000, /*sec_key=*/200);
+
+  bool threw = false;
+  nanots_ec_t ec = NANOTS_EC_OK;
+  try {
+    // Lower sec_key than previous; must throw even though ts is higher.
+    db.write(wctx, (uint8_t*)"c", 1, 0, 3000, /*sec_key=*/150);
+  } catch (const nanots_exception& e) {
+    threw = true;
+    ec = e.get_ec();
+  }
+  RTF_ASSERT(threw);
+  RTF_ASSERT(ec == NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY);
+
+  // Equal sec_key also rejected (strict monotonic).
+  threw = false;
+  try {
+    db.write(wctx, (uint8_t*)"d", 1, 0, 3000, /*sec_key=*/200);
+  } catch (const nanots_exception& e) {
+    threw = true;
+    ec = e.get_ec();
+  }
+  RTF_ASSERT(threw);
+  RTF_ASSERT(ec == NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY);
+
+  // Strictly greater sec_key succeeds.
+  db.write(wctx, (uint8_t*)"e", 1, 0, 3000, /*sec_key=*/300);
+}
+
+// A file with no v2 magic at offset 0 must be rejected on open. We synthesise
+// the legacy v1 header (block_size at offset 0, n_blocks at offset 4) and
+// verify the writer ctor throws NANOTS_EC_BAD_MAGIC.
+void test_nanots::test_nanots_v1_file_rejected() {
+  const char* nts = "nanots_legacy_v1.nts";
+  // Whack any leftovers.
+  if (rtf_file_exists(nts)) rtf_remove_file(nts);
+  std::string db_name = "nanots_legacy_v1.db";
+  if (rtf_file_exists(db_name.c_str())) rtf_remove_file(db_name.c_str());
+
+  // Create a tiny file that looks like a legacy v1 header: 4 byte block_size,
+  // 4 byte n_blocks. Padded out to 64KB.
+  {
+    auto f = nts_file::open(nts, "w+");
+    std::vector<uint8_t> hdr(FILE_HEADER_BLOCK_SIZE, 0);
+    *(uint32_t*)(hdr.data() + 0) = 64 * 1024;  // block_size
+    *(uint32_t*)(hdr.data() + 4) = 1;          // n_blocks
+    fwrite(hdr.data(), 1, hdr.size(), f);
+    // One empty block so the file has a sensible size.
+    std::vector<uint8_t> blk(64 * 1024, 0);
+    fwrite(blk.data(), 1, blk.size(), f);
+    f.close();
+  }
+
+  // nanots_writer ctor must reject it.
+  bool threw = false;
+  nanots_ec_t ec = NANOTS_EC_OK;
+  try {
+    nanots_writer w(nts, false);
+  } catch (const nanots_exception& e) {
+    threw = true;
+    ec = e.get_ec();
+  }
+  RTF_ASSERT(threw);
+  RTF_ASSERT(ec == NANOTS_EC_BAD_MAGIC);
+
+  // nanots_reader ctor must reject it too.
+  threw = false;
+  try {
+    nanots_reader r(nts);
+  } catch (const nanots_exception& e) {
+    threw = true;
+    ec = e.get_ec();
+  }
+  RTF_ASSERT(threw);
+  RTF_ASSERT(ec == NANOTS_EC_BAD_MAGIC);
+
+  // Cleanup.
+  if (rtf_file_exists(nts)) rtf_remove_file(nts);
+  if (rtf_file_exists(db_name.c_str())) rtf_remove_file(db_name.c_str());
+}
+
+// Force many frames so the stream spans multiple blocks, then exercise
+// find_by_secondary_key across block boundaries (the SQL-backed _ts_index
+// lookup) and verify ++/-- around the boundary.
+void test_nanots::test_nanots_secondary_key_cross_blocks() {
+  // 4 KB blocks → ~3 frames per block at 1 KB rows; 64 frames = ~22 blocks.
+  nanots_writer db("nanots_test_2048_4k_blocks.nts", false);
+
+  const int N = 64;
+  {
+    auto wctx = db.create_write_context("sk_cross", "");
+    std::vector<uint8_t> row(1024, 0xCC);
+    for (int i = 0; i < N; i++) {
+      // Distinctive: timestamp and sec_key advance at *different* rates so
+      // the two indexes can't accidentally substitute for each other.
+      db.write(wctx, row.data(), row.size(), 0,
+               /*ts=*/1000 + i * 10,
+               /*sec_key=*/500 + i * 73);
+    }
+  }
+
+  nanots_iterator iter("nanots_test_2048_4k_blocks.nts", "sk_cross");
+  RTF_ASSERT(iter.has_secondary_key());
+
+  // Confirm we actually filled multiple blocks (otherwise this test isn't
+  // doing what it claims).
+  std::set<int64_t> blocks_seen;
+  iter.reset();
+  while (iter.valid()) {
+    blocks_seen.insert(iter->block_sequence);
+    ++iter;
+  }
+  printf("sk_cross blocks: %zu\n", blocks_seen.size());
+  RTF_ASSERT(blocks_seen.size() > 1);
+
+  // Walk every frame via find_by_secondary_key and verify we land on the
+  // right one. Frame i has sec_key = 500 + i*73.
+  for (int i = 0; i < N; i++) {
+    int64_t target = 500 + i * 73;
+    RTF_ASSERT(iter.find_by_secondary_key(target));
+    RTF_ASSERT(iter->secondary_key == target);
+    RTF_ASSERT(iter->timestamp == 1000 + i * 10);
+  }
+
+  // Find between two keys → next higher.
+  RTF_ASSERT(iter.find_by_secondary_key(500 + 5 * 73 + 1));
+  RTF_ASSERT(iter->secondary_key == 500 + 6 * 73);
+}
+
+// After a find_by_secondary_key, ++ and -- must walk by physical order
+// (which for monotonic streams is the same as sec-key order).
+void test_nanots::test_nanots_secondary_key_bidirectional() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+
+  const int N = 20;
+  {
+    auto wctx = db.create_write_context("sk_bidi", "");
+    for (int i = 0; i < N; i++) {
+      std::string d = "bidi_" + std::to_string(i);
+      db.write(wctx, (uint8_t*)d.c_str(), d.size(), 0,
+               /*ts=*/1000 + i, /*sec_key=*/100 + i * 11);
+    }
+  }
+
+  nanots_iterator iter("nanots_test_4mb.nts", "sk_bidi");
+
+  // Land in the middle by sec key.
+  RTF_ASSERT(iter.find_by_secondary_key(100 + 10 * 11));
+  RTF_ASSERT(iter->secondary_key == 100 + 10 * 11);
+
+  // Walk forward.
+  for (int i = 11; i < N; i++) {
+    ++iter;
+    RTF_ASSERT(iter.valid());
+    RTF_ASSERT(iter->secondary_key == 100 + i * 11);
+  }
+  ++iter;
+  RTF_ASSERT(!iter.valid());
+
+  // Reseek and walk backward.
+  RTF_ASSERT(iter.find_by_secondary_key(100 + 5 * 11));
+  for (int i = 4; i >= 0; i--) {
+    --iter;
+    RTF_ASSERT(iter.valid());
+    RTF_ASSERT(iter->secondary_key == 100 + i * 11);
+  }
+  --iter;
+  RTF_ASSERT(!iter.valid());
+}
+
+// Multiple write contexts (= multiple segments) on the same stream. All must
+// be keyed (locked by the first segment), and find/iterate must cross
+// segment boundaries cleanly.
+void test_nanots::test_nanots_secondary_key_multi_segment() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+
+  // Segment 1.
+  {
+    auto wctx = db.create_write_context("sk_segs", "s1");
+    for (int i = 0; i < 5; i++) {
+      std::string d = "s1_" + std::to_string(i);
+      db.write(wctx, (uint8_t*)d.c_str(), d.size(), 0,
+               1000 + i, /*sec_key=*/100 + i);
+    }
+  }
+  // Segment 2 (must remain keyed).
+  {
+    auto wctx = db.create_write_context("sk_segs", "s2");
+    for (int i = 0; i < 5; i++) {
+      std::string d = "s2_" + std::to_string(i);
+      db.write(wctx, (uint8_t*)d.c_str(), d.size(), 0,
+               2000 + i, /*sec_key=*/200 + i);
+    }
+  }
+  // Segment 3.
+  {
+    auto wctx = db.create_write_context("sk_segs", "s3");
+    for (int i = 0; i < 5; i++) {
+      std::string d = "s3_" + std::to_string(i);
+      db.write(wctx, (uint8_t*)d.c_str(), d.size(), 0,
+               3000 + i, /*sec_key=*/300 + i);
+    }
+  }
+
+  nanots_iterator iter("nanots_test_4mb.nts", "sk_segs");
+  RTF_ASSERT(iter.has_secondary_key());
+
+  // Find in segment 1.
+  RTF_ASSERT(iter.find_by_secondary_key(102));
+  RTF_ASSERT(iter->secondary_key == 102);
+  RTF_ASSERT(iter.current_metadata() == "s1");
+
+  // Find in segment 2.
+  RTF_ASSERT(iter.find_by_secondary_key(201));
+  RTF_ASSERT(iter->secondary_key == 201);
+  RTF_ASSERT(iter.current_metadata() == "s2");
+
+  // Find in segment 3.
+  RTF_ASSERT(iter.find_by_secondary_key(304));
+  RTF_ASSERT(iter->secondary_key == 304);
+  RTF_ASSERT(iter.current_metadata() == "s3");
+
+  // Find between segments — should land on first frame of next segment.
+  RTF_ASSERT(iter.find_by_secondary_key(150));
+  RTF_ASSERT(iter->secondary_key == 200);
+  RTF_ASSERT(iter.current_metadata() == "s2");
+
+  // Walk all 15 frames in order by repeatedly stepping forward from the
+  // very first key.
+  RTF_ASSERT(iter.find_by_secondary_key(0));
+  int seen = 0;
+  int64_t last_sk = -1;
+  while (iter.valid()) {
+    RTF_ASSERT(iter->secondary_key > last_sk);
+    last_sk = iter->secondary_key;
+    seen++;
+    ++iter;
+  }
+  RTF_ASSERT(seen == 15);
+}
+
+// On an unkeyed stream, find_by_secondary_key must fail cleanly.
+void test_nanots::test_nanots_secondary_key_unkeyed_stream_rejects_find() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+  {
+    auto wctx = db.create_write_context("plain", "");
+    for (int i = 0; i < 5; i++) {
+      db.write(wctx, (uint8_t*)"x", 1, 0, 1000 + i);
+    }
+  }
+
+  nanots_iterator iter("nanots_test_4mb.nts", "plain");
+  RTF_ASSERT(!iter.has_secondary_key());
+
+  // The iterator is valid (pointing at the first frame).
+  RTF_ASSERT(iter.valid());
+
+  // find_by_secondary_key returns false and invalidates the iterator.
+  RTF_ASSERT(!iter.find_by_secondary_key(123));
+  RTF_ASSERT(!iter.valid());
+
+  // Iterator can be recovered with reset().
+  iter.reset();
+  RTF_ASSERT(iter.valid());
+  RTF_ASSERT(iter->secondary_key == NANOTS_SEC_KEY_UNSET);
+}
+
+// Two streams in the same file: one keyed, one unkeyed. They must not
+// interfere with each other.
+void test_nanots::test_nanots_secondary_key_mixed_streams_same_file() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+  {
+    auto keyed   = db.create_write_context("keyed", "k");
+    auto unkeyed = db.create_write_context("unkeyed", "u");
+    for (int i = 0; i < 5; i++) {
+      db.write(keyed, (uint8_t*)"k", 1, 0, 1000 + i, /*sec_key=*/10 + i);
+      db.write(unkeyed, (uint8_t*)"u", 1, 0, 2000 + i);
+    }
+  }
+
+  // Keyed stream: has_secondary_key true, find_by_secondary_key works.
+  {
+    nanots_iterator it("nanots_test_4mb.nts", "keyed");
+    RTF_ASSERT(it.has_secondary_key());
+    RTF_ASSERT(it.find_by_secondary_key(12));
+    RTF_ASSERT(it->secondary_key == 12);
+    RTF_ASSERT(it->timestamp == 1002);
+  }
+
+  // Unkeyed stream: has_secondary_key false, find_by_secondary_key fails.
+  {
+    nanots_iterator it("nanots_test_4mb.nts", "unkeyed");
+    RTF_ASSERT(!it.has_secondary_key());
+    RTF_ASSERT(it.valid());
+    RTF_ASSERT(it->secondary_key == NANOTS_SEC_KEY_UNSET);
+    RTF_ASSERT(!it.find_by_secondary_key(0));
+    // Normal timestamp seeking on the unkeyed stream still works.
+    it.reset();
+    RTF_ASSERT(it.find(2003));
+    RTF_ASSERT(it->timestamp == 2003);
+  }
+}
+
+// Sparse keys: huge gaps must still binary-search correctly.
+void test_nanots::test_nanots_secondary_key_sparse() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+
+  // Keys span 0 .. 10^15 in geometric-ish steps.
+  std::vector<int64_t> keys = {
+      1, 100, 10000, 1000000, 100000000, 10000000000LL,
+      1000000000000LL, 100000000000000LL, 1000000000000000LL,
+  };
+  {
+    auto wctx = db.create_write_context("sk_sparse", "");
+    for (size_t i = 0; i < keys.size(); i++) {
+      std::string d = "sp_" + std::to_string(i);
+      db.write(wctx, (uint8_t*)d.c_str(), d.size(), 0,
+               /*ts=*/1000 + (int64_t)i, /*sec_key=*/keys[i]);
+    }
+  }
+
+  nanots_iterator iter("nanots_test_4mb.nts", "sk_sparse");
+  RTF_ASSERT(iter.has_secondary_key());
+
+  // Exact matches.
+  for (size_t i = 0; i < keys.size(); i++) {
+    RTF_ASSERT(iter.find_by_secondary_key(keys[i]));
+    RTF_ASSERT(iter->secondary_key == keys[i]);
+  }
+
+  // Between-key seeks land on next higher.
+  RTF_ASSERT(iter.find_by_secondary_key(50));
+  RTF_ASSERT(iter->secondary_key == 100);
+  RTF_ASSERT(iter.find_by_secondary_key(99999));
+  RTF_ASSERT(iter->secondary_key == 1000000);
+  RTF_ASSERT(iter.find_by_secondary_key(999999999999LL));
+  RTF_ASSERT(iter->secondary_key == 1000000000000LL);
+
+  // Below the smallest → first.
+  RTF_ASSERT(iter.find_by_secondary_key(0));
+  RTF_ASSERT(iter->secondary_key == 1);
+
+  // Above the largest → invalid.
+  RTF_ASSERT(!iter.find_by_secondary_key(9999999999999999LL));
+  RTF_ASSERT(!iter.valid());
+}
+
+// Secondary keys are int64, signed. Negative keys and values close to
+// INT64_MAX must work. INT64_MIN is reserved as the "unset" sentinel and is
+// implicitly off-limits for keyed streams.
+void test_nanots::test_nanots_secondary_key_extreme_values() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+
+  // Strictly increasing sequence of "interesting" int64 values.
+  std::vector<int64_t> keys = {
+      INT64_MIN + 1,        // smallest legal key (INT64_MIN is the sentinel)
+      -1000000000000LL,
+      -1,
+      0,
+      1,
+      1000000000000LL,
+      INT64_MAX - 1,
+      INT64_MAX,
+  };
+  {
+    auto wctx = db.create_write_context("sk_extreme", "");
+    for (size_t i = 0; i < keys.size(); i++) {
+      std::string d = "ex_" + std::to_string(i);
+      db.write(wctx, (uint8_t*)d.c_str(), d.size(), 0,
+               /*ts=*/1000 + (int64_t)i, keys[i]);
+    }
+  }
+
+  nanots_iterator iter("nanots_test_4mb.nts", "sk_extreme");
+  RTF_ASSERT(iter.has_secondary_key());
+
+  // Round-trip each value.
+  for (size_t i = 0; i < keys.size(); i++) {
+    RTF_ASSERT(iter.find_by_secondary_key(keys[i]));
+    RTF_ASSERT(iter->secondary_key == keys[i]);
+  }
+
+  // Boundary: searching for INT64_MIN (= sentinel) on a keyed stream should
+  // land on the smallest real key (INT64_MIN + 1).
+  RTF_ASSERT(iter.find_by_secondary_key(INT64_MIN));
+  RTF_ASSERT(iter->secondary_key == INT64_MIN + 1);
+
+  // Going below INT64_MIN + 1 lands on the first real key (already the
+  // smallest, but exercise the lower-bound path).
+  RTF_ASSERT(iter.find_by_secondary_key(INT64_MIN + 1));
+  RTF_ASSERT(iter->secondary_key == INT64_MIN + 1);
+  // Step backwards from there → invalid.
+  --iter;
+  RTF_ASSERT(!iter.valid());
+
+  // Step forward from INT64_MAX (the last frame) → invalid.
+  RTF_ASSERT(iter.find_by_secondary_key(INT64_MAX));
+  ++iter;
+  RTF_ASSERT(!iter.valid());
+}
+
+// The reader callback must surface the secondary key for keyed streams,
+// and NANOTS_SEC_KEY_UNSET for unkeyed streams.
+void test_nanots::test_nanots_secondary_key_reader_callback() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+  {
+    auto k = db.create_write_context("rk_keyed", "");
+    for (int i = 0; i < 4; i++) {
+      db.write(k, (uint8_t*)"x", 1, 0, 1000 + i, /*sec_key=*/500 + i);
+    }
+    auto u = db.create_write_context("rk_unkeyed", "");
+    for (int i = 0; i < 4; i++) {
+      db.write(u, (uint8_t*)"y", 1, 0, 2000 + i);
+    }
+  }
+
+  nanots_reader reader("nanots_test_4mb.nts");
+
+  // Keyed: every callback should see the right sec_key.
+  std::vector<int64_t> seen_keyed;
+  reader.read("rk_keyed", 0, 100000,
+              [&](const uint8_t* data, size_t size, uint32_t flags,
+                  int64_t ts, int64_t sk,
+                  int64_t block_seq, const std::string& meta) {
+                seen_keyed.push_back(sk);
+              });
+  RTF_ASSERT(seen_keyed.size() == 4);
+  for (int i = 0; i < 4; i++) {
+    RTF_ASSERT(seen_keyed[i] == 500 + i);
+  }
+
+  // Unkeyed: every callback should see NANOTS_SEC_KEY_UNSET.
+  std::vector<int64_t> seen_unkeyed;
+  reader.read("rk_unkeyed", 0, 100000,
+              [&](const uint8_t* data, size_t size, uint32_t flags,
+                  int64_t ts, int64_t sk,
+                  int64_t block_seq, const std::string& meta) {
+                seen_unkeyed.push_back(sk);
+              });
+  RTF_ASSERT(seen_unkeyed.size() == 4);
+  for (auto sk : seen_unkeyed) {
+    RTF_ASSERT(sk == NANOTS_SEC_KEY_UNSET);
+  }
 }

--- a/ut/source/test_nanots.cpp
+++ b/ut/source/test_nanots.cpp
@@ -2198,7 +2198,6 @@ void test_nanots::test_nanots_secondary_key_basic() {
 
   // Iterator round-trip.
   nanots_iterator iter("nanots_test_4mb.nts", "sk_stream");
-  RTF_ASSERT(iter.has_secondary_key());
   int i = 0;
   while (iter.valid()) {
     RTF_ASSERT(iter->timestamp == 1000 + i * 100);
@@ -2222,12 +2221,13 @@ void test_nanots::test_nanots_secondary_key_basic() {
   RTF_ASSERT(j == 10);
 }
 
-// Verify find_by_secondary_key works the same way find(timestamp) does:
-// exact match, between-keys lands on next-higher, before-first lands on
-// first, after-last invalidates.
+// Composite find() with both args: exact composite match, between-key lands
+// on next-higher composite, etc.
 void test_nanots::test_nanots_secondary_key_find() {
   nanots_writer db("nanots_test_4mb.nts", false);
 
+  // Write 10 frames with strictly-increasing timestamps and sec_keys.
+  // Composite is just lex on (ts, sk).
   {
     auto wctx = db.create_write_context("sk_find", "");
     for (int i = 0; i < 10; i++) {
@@ -2238,117 +2238,81 @@ void test_nanots::test_nanots_secondary_key_find() {
   }
 
   nanots_iterator iter("nanots_test_4mb.nts", "sk_find");
-  RTF_ASSERT(iter.has_secondary_key());
 
-  // Exact match.
-  RTF_ASSERT(iter.find_by_secondary_key(2000));
+  // Exact composite match: (1200, 2000) is frame 2.
+  RTF_ASSERT(iter.find(1200, 2000));
+  RTF_ASSERT(iter->timestamp == 1200);
   RTF_ASSERT(iter->secondary_key == 2000);
 
-  // Between keys → next higher.
-  RTF_ASSERT(iter.find_by_secondary_key(2250));
+  // Between composites: (1200, 2001) → next composite (1300, 2500).
+  RTF_ASSERT(iter.find(1200, 2001));
+  RTF_ASSERT(iter->timestamp == 1300);
   RTF_ASSERT(iter->secondary_key == 2500);
 
-  // Before first.
-  RTF_ASSERT(iter.find_by_secondary_key(0));
+  // Before first composite.
+  RTF_ASSERT(iter.find(0, NANOTS_SEC_KEY_UNSET));
+  RTF_ASSERT(iter->timestamp == 1000);
   RTF_ASSERT(iter->secondary_key == 1000);
 
-  // Past last.
-  RTF_ASSERT(!iter.find_by_secondary_key(100000));
+  // Past last composite.
+  RTF_ASSERT(!iter.find(99999, 99999));
   RTF_ASSERT(!iter.valid());
+
+  // Find with default sec_key (= UNSET): lands on first frame at the given
+  // timestamp (smallest sec_key wins).
+  RTF_ASSERT(iter.find(1500));  // = find(1500, NANOTS_SEC_KEY_UNSET)
+  RTF_ASSERT(iter->timestamp == 1500);
 }
 
-// Mixing keyed and unkeyed writes on the same stream is rejected.
-void test_nanots::test_nanots_secondary_key_mismatch() {
-  nanots_writer db("nanots_test_4mb.nts", false);
-
-  // Case 1: stream is locked as "keyed" on first write; later unkeyed write
-  // throws.
-  {
-    auto wctx = db.create_write_context("sk_mismatch_a", "");
-    db.write(wctx, (uint8_t*)"a", 1, 0, 1000, /*sec_key=*/42);
-
-    bool threw = false;
-    nanots_ec_t ec = NANOTS_EC_OK;
-    try {
-      db.write(wctx, (uint8_t*)"b", 1, 0, 1100);
-    } catch (const nanots_exception& e) {
-      threw = true;
-      ec = e.get_ec();
-    }
-    RTF_ASSERT(threw);
-    RTF_ASSERT(ec == NANOTS_EC_SECONDARY_KEY_MISMATCH);
-  }
-
-  // Case 2: stream locked as "unkeyed"; later keyed write throws.
-  {
-    auto wctx = db.create_write_context("sk_mismatch_b", "");
-    db.write(wctx, (uint8_t*)"a", 1, 0, 1000);
-
-    bool threw = false;
-    nanots_ec_t ec = NANOTS_EC_OK;
-    try {
-      db.write(wctx, (uint8_t*)"b", 1, 0, 1100, /*sec_key=*/99);
-    } catch (const nanots_exception& e) {
-      threw = true;
-      ec = e.get_ec();
-    }
-    RTF_ASSERT(threw);
-    RTF_ASSERT(ec == NANOTS_EC_SECONDARY_KEY_MISMATCH);
-  }
-
-  // Case 3: a new write_context on a previously-keyed stream must continue
-  // to be keyed; passing UNSET in the first write of the new context throws.
-  {
-    {
-      auto wctx = db.create_write_context("sk_mismatch_c", "");
-      db.write(wctx, (uint8_t*)"a", 1, 0, 1000, /*sec_key=*/1);
-    }
-    auto wctx2 = db.create_write_context("sk_mismatch_c", "");
-    bool threw = false;
-    try {
-      db.write(wctx2, (uint8_t*)"b", 1, 0, 2000);
-    } catch (const nanots_exception& e) {
-      threw = true;
-      RTF_ASSERT(e.get_ec() == NANOTS_EC_SECONDARY_KEY_MISMATCH);
-    }
-    RTF_ASSERT(threw);
-  }
-}
-
-// Secondary key must be monotonic within a write context, same rule as
-// timestamps.
+// Composite monotonicity: (ts, sk) must strictly increase across writes.
+// Ties on ts are fine if sk strictly increases; ts may jump as long as the
+// composite still moves forward.
 void test_nanots::test_nanots_secondary_key_monotonic() {
   nanots_writer db("nanots_test_4mb.nts", false);
   auto wctx = db.create_write_context("sk_mono", "");
 
   db.write(wctx, (uint8_t*)"a", 1, 0, 1000, /*sec_key=*/100);
-  db.write(wctx, (uint8_t*)"b", 1, 0, 2000, /*sec_key=*/200);
+  // Same ts, greater sk: allowed.
+  db.write(wctx, (uint8_t*)"b", 1, 0, 1000, /*sec_key=*/200);
+  // Greater ts, smaller sk: allowed (ts wins in lex order).
+  db.write(wctx, (uint8_t*)"c", 1, 0, 2000, /*sec_key=*/50);
 
+  // Smaller ts: rejected.
   bool threw = false;
   nanots_ec_t ec = NANOTS_EC_OK;
   try {
-    // Lower sec_key than previous; must throw even though ts is higher.
-    db.write(wctx, (uint8_t*)"c", 1, 0, 3000, /*sec_key=*/150);
+    db.write(wctx, (uint8_t*)"d", 1, 0, 1500, /*sec_key=*/999);
   } catch (const nanots_exception& e) {
     threw = true;
     ec = e.get_ec();
   }
   RTF_ASSERT(threw);
-  RTF_ASSERT(ec == NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY);
+  RTF_ASSERT(ec == NANOTS_EC_NON_MONOTONIC_TIMESTAMP);
 
-  // Equal sec_key also rejected (strict monotonic).
+  // Same composite (ts, sk) — rejected (strict).
   threw = false;
   try {
-    db.write(wctx, (uint8_t*)"d", 1, 0, 3000, /*sec_key=*/200);
+    db.write(wctx, (uint8_t*)"e", 1, 0, 2000, /*sec_key=*/50);
   } catch (const nanots_exception& e) {
     threw = true;
     ec = e.get_ec();
   }
   RTF_ASSERT(threw);
-  RTF_ASSERT(ec == NANOTS_EC_NON_MONOTONIC_SECONDARY_KEY);
+  RTF_ASSERT(ec == NANOTS_EC_NON_MONOTONIC_TIMESTAMP);
 
-  // Strictly greater sec_key succeeds.
-  db.write(wctx, (uint8_t*)"e", 1, 0, 3000, /*sec_key=*/300);
+  // Same ts, equal sk — rejected (strict on the composite).
+  threw = false;
+  try {
+    db.write(wctx, (uint8_t*)"f", 1, 0, 2000, /*sec_key=*/50);
+  } catch (const nanots_exception& e) {
+    threw = true;
+    ec = e.get_ec();
+  }
+  RTF_ASSERT(threw);
+  RTF_ASSERT(ec == NANOTS_EC_NON_MONOTONIC_TIMESTAMP);
+
+  // Same ts, larger sk — OK.
+  db.write(wctx, (uint8_t*)"g", 1, 0, 2000, /*sec_key=*/51);
 }
 
 // A file with no v2 magic at offset 0 must be rejected on open. We synthesise
@@ -2404,8 +2368,8 @@ void test_nanots::test_nanots_v1_file_rejected() {
 }
 
 // Force many frames so the stream spans multiple blocks, then exercise
-// find_by_secondary_key across block boundaries (the SQL-backed _ts_index
-// lookup) and verify ++/-- around the boundary.
+// composite find() across block boundaries and verify ++/-- around the
+// boundary.
 void test_nanots::test_nanots_secondary_key_cross_blocks() {
   // 4 KB blocks → ~3 frames per block at 1 KB rows; 64 frames = ~22 blocks.
   nanots_writer db("nanots_test_2048_4k_blocks.nts", false);
@@ -2415,8 +2379,7 @@ void test_nanots::test_nanots_secondary_key_cross_blocks() {
     auto wctx = db.create_write_context("sk_cross", "");
     std::vector<uint8_t> row(1024, 0xCC);
     for (int i = 0; i < N; i++) {
-      // Distinctive: timestamp and sec_key advance at *different* rates so
-      // the two indexes can't accidentally substitute for each other.
+      // Distinctive: timestamp and sec_key advance at *different* rates.
       db.write(wctx, row.data(), row.size(), 0,
                /*ts=*/1000 + i * 10,
                /*sec_key=*/500 + i * 73);
@@ -2424,10 +2387,8 @@ void test_nanots::test_nanots_secondary_key_cross_blocks() {
   }
 
   nanots_iterator iter("nanots_test_2048_4k_blocks.nts", "sk_cross");
-  RTF_ASSERT(iter.has_secondary_key());
 
-  // Confirm we actually filled multiple blocks (otherwise this test isn't
-  // doing what it claims).
+  // Confirm we actually filled multiple blocks.
   std::set<int64_t> blocks_seen;
   iter.reset();
   while (iter.valid()) {
@@ -2437,22 +2398,24 @@ void test_nanots::test_nanots_secondary_key_cross_blocks() {
   printf("sk_cross blocks: %zu\n", blocks_seen.size());
   RTF_ASSERT(blocks_seen.size() > 1);
 
-  // Walk every frame via find_by_secondary_key and verify we land on the
-  // right one. Frame i has sec_key = 500 + i*73.
+  // Walk every frame via composite find() and verify we land on the right one.
   for (int i = 0; i < N; i++) {
-    int64_t target = 500 + i * 73;
-    RTF_ASSERT(iter.find_by_secondary_key(target));
-    RTF_ASSERT(iter->secondary_key == target);
-    RTF_ASSERT(iter->timestamp == 1000 + i * 10);
+    int64_t ts = 1000 + i * 10;
+    int64_t sk = 500 + i * 73;
+    RTF_ASSERT(iter.find(ts, sk));
+    RTF_ASSERT(iter->secondary_key == sk);
+    RTF_ASSERT(iter->timestamp == ts);
   }
 
-  // Find between two keys → next higher.
-  RTF_ASSERT(iter.find_by_secondary_key(500 + 5 * 73 + 1));
-  RTF_ASSERT(iter->secondary_key == 500 + 6 * 73);
+  // Find between two composites → next higher composite. Frame 5 is
+  // (1050, 865); frame 6 is (1060, 938). (1050, 866) is between them in
+  // lex order.
+  RTF_ASSERT(iter.find(1050, 866));
+  RTF_ASSERT(iter->timestamp == 1060);
+  RTF_ASSERT(iter->secondary_key == 938);
 }
 
-// After a find_by_secondary_key, ++ and -- must walk by physical order
-// (which for monotonic streams is the same as sec-key order).
+// After a composite find(), ++ and -- must walk by physical order.
 void test_nanots::test_nanots_secondary_key_bidirectional() {
   nanots_writer db("nanots_test_4mb.nts", false);
 
@@ -2468,9 +2431,10 @@ void test_nanots::test_nanots_secondary_key_bidirectional() {
 
   nanots_iterator iter("nanots_test_4mb.nts", "sk_bidi");
 
-  // Land in the middle by sec key.
-  RTF_ASSERT(iter.find_by_secondary_key(100 + 10 * 11));
+  // Land in the middle by composite.
+  RTF_ASSERT(iter.find(1010, 100 + 10 * 11));
   RTF_ASSERT(iter->secondary_key == 100 + 10 * 11);
+  RTF_ASSERT(iter->timestamp == 1010);
 
   // Walk forward.
   for (int i = 11; i < N; i++) {
@@ -2482,7 +2446,7 @@ void test_nanots::test_nanots_secondary_key_bidirectional() {
   RTF_ASSERT(!iter.valid());
 
   // Reseek and walk backward.
-  RTF_ASSERT(iter.find_by_secondary_key(100 + 5 * 11));
+  RTF_ASSERT(iter.find(1005, 100 + 5 * 11));
   for (int i = 4; i >= 0; i--) {
     --iter;
     RTF_ASSERT(iter.valid());
@@ -2492,9 +2456,8 @@ void test_nanots::test_nanots_secondary_key_bidirectional() {
   RTF_ASSERT(!iter.valid());
 }
 
-// Multiple write contexts (= multiple segments) on the same stream. All must
-// be keyed (locked by the first segment), and find/iterate must cross
-// segment boundaries cleanly.
+// Multiple write contexts (= multiple segments) on the same stream. find()
+// and iteration must cross segment boundaries cleanly.
 void test_nanots::test_nanots_secondary_key_multi_segment() {
   nanots_writer db("nanots_test_4mb.nts", false);
 
@@ -2507,7 +2470,6 @@ void test_nanots::test_nanots_secondary_key_multi_segment() {
                1000 + i, /*sec_key=*/100 + i);
     }
   }
-  // Segment 2 (must remain keyed).
   {
     auto wctx = db.create_write_context("sk_segs", "s2");
     for (int i = 0; i < 5; i++) {
@@ -2516,7 +2478,6 @@ void test_nanots::test_nanots_secondary_key_multi_segment() {
                2000 + i, /*sec_key=*/200 + i);
     }
   }
-  // Segment 3.
   {
     auto wctx = db.create_write_context("sk_segs", "s3");
     for (int i = 0; i < 5; i++) {
@@ -2527,70 +2488,40 @@ void test_nanots::test_nanots_secondary_key_multi_segment() {
   }
 
   nanots_iterator iter("nanots_test_4mb.nts", "sk_segs");
-  RTF_ASSERT(iter.has_secondary_key());
 
   // Find in segment 1.
-  RTF_ASSERT(iter.find_by_secondary_key(102));
+  RTF_ASSERT(iter.find(1002, 102));
   RTF_ASSERT(iter->secondary_key == 102);
   RTF_ASSERT(iter.current_metadata() == "s1");
 
   // Find in segment 2.
-  RTF_ASSERT(iter.find_by_secondary_key(201));
+  RTF_ASSERT(iter.find(2001, 201));
   RTF_ASSERT(iter->secondary_key == 201);
   RTF_ASSERT(iter.current_metadata() == "s2");
 
   // Find in segment 3.
-  RTF_ASSERT(iter.find_by_secondary_key(304));
+  RTF_ASSERT(iter.find(3004, 304));
   RTF_ASSERT(iter->secondary_key == 304);
   RTF_ASSERT(iter.current_metadata() == "s3");
 
-  // Find between segments — should land on first frame of next segment.
-  RTF_ASSERT(iter.find_by_secondary_key(150));
+  // Find between segments — composite (1500, 0) lands on first frame of
+  // segment 2 (the first composite >= (1500, 0)).
+  RTF_ASSERT(iter.find(1500, 0));
   RTF_ASSERT(iter->secondary_key == 200);
   RTF_ASSERT(iter.current_metadata() == "s2");
 
-  // Walk all 15 frames in order by repeatedly stepping forward from the
-  // very first key.
-  RTF_ASSERT(iter.find_by_secondary_key(0));
+  // Walk all 15 frames in composite order from before-the-first.
+  RTF_ASSERT(iter.find(0));
   int seen = 0;
-  int64_t last_sk = -1;
   while (iter.valid()) {
-    RTF_ASSERT(iter->secondary_key > last_sk);
-    last_sk = iter->secondary_key;
     seen++;
     ++iter;
   }
   RTF_ASSERT(seen == 15);
 }
 
-// On an unkeyed stream, find_by_secondary_key must fail cleanly.
-void test_nanots::test_nanots_secondary_key_unkeyed_stream_rejects_find() {
-  nanots_writer db("nanots_test_4mb.nts", false);
-  {
-    auto wctx = db.create_write_context("plain", "");
-    for (int i = 0; i < 5; i++) {
-      db.write(wctx, (uint8_t*)"x", 1, 0, 1000 + i);
-    }
-  }
-
-  nanots_iterator iter("nanots_test_4mb.nts", "plain");
-  RTF_ASSERT(!iter.has_secondary_key());
-
-  // The iterator is valid (pointing at the first frame).
-  RTF_ASSERT(iter.valid());
-
-  // find_by_secondary_key returns false and invalidates the iterator.
-  RTF_ASSERT(!iter.find_by_secondary_key(123));
-  RTF_ASSERT(!iter.valid());
-
-  // Iterator can be recovered with reset().
-  iter.reset();
-  RTF_ASSERT(iter.valid());
-  RTF_ASSERT(iter->secondary_key == NANOTS_SEC_KEY_UNSET);
-}
-
-// Two streams in the same file: one keyed, one unkeyed. They must not
-// interfere with each other.
+// Two streams in the same file: one keyed, one unkeyed (always passes UNSET
+// for sec_key, so composite degenerates to ts-monotonic).
 void test_nanots::test_nanots_secondary_key_mixed_streams_same_file() {
   nanots_writer db("nanots_test_4mb.nts", false);
   {
@@ -2602,34 +2533,30 @@ void test_nanots::test_nanots_secondary_key_mixed_streams_same_file() {
     }
   }
 
-  // Keyed stream: has_secondary_key true, find_by_secondary_key works.
+  // Keyed stream: composite find works.
   {
     nanots_iterator it("nanots_test_4mb.nts", "keyed");
-    RTF_ASSERT(it.has_secondary_key());
-    RTF_ASSERT(it.find_by_secondary_key(12));
+    RTF_ASSERT(it.find(1002, 12));
     RTF_ASSERT(it->secondary_key == 12);
     RTF_ASSERT(it->timestamp == 1002);
   }
 
-  // Unkeyed stream: has_secondary_key false, find_by_secondary_key fails.
+  // Unkeyed stream: every frame's sec_key reads as UNSET; find by ts works
+  // normally (sec_key defaults to UNSET so composite = (ts, UNSET)).
   {
     nanots_iterator it("nanots_test_4mb.nts", "unkeyed");
-    RTF_ASSERT(!it.has_secondary_key());
     RTF_ASSERT(it.valid());
     RTF_ASSERT(it->secondary_key == NANOTS_SEC_KEY_UNSET);
-    RTF_ASSERT(!it.find_by_secondary_key(0));
-    // Normal timestamp seeking on the unkeyed stream still works.
-    it.reset();
     RTF_ASSERT(it.find(2003));
     RTF_ASSERT(it->timestamp == 2003);
+    RTF_ASSERT(it->secondary_key == NANOTS_SEC_KEY_UNSET);
   }
 }
 
-// Sparse keys: huge gaps must still binary-search correctly.
+// Sparse composites: huge gaps must still binary-search correctly.
 void test_nanots::test_nanots_secondary_key_sparse() {
   nanots_writer db("nanots_test_4mb.nts", false);
 
-  // Keys span 0 .. 10^15 in geometric-ish steps.
   std::vector<int64_t> keys = {
       1, 100, 10000, 1000000, 100000000, 10000000000LL,
       1000000000000LL, 100000000000000LL, 1000000000000000LL,
@@ -2644,40 +2571,44 @@ void test_nanots::test_nanots_secondary_key_sparse() {
   }
 
   nanots_iterator iter("nanots_test_4mb.nts", "sk_sparse");
-  RTF_ASSERT(iter.has_secondary_key());
 
-  // Exact matches.
+  // Exact composite matches.
   for (size_t i = 0; i < keys.size(); i++) {
-    RTF_ASSERT(iter.find_by_secondary_key(keys[i]));
+    int64_t ts = 1000 + (int64_t)i;
+    RTF_ASSERT(iter.find(ts, keys[i]));
     RTF_ASSERT(iter->secondary_key == keys[i]);
+    RTF_ASSERT(iter->timestamp == ts);
   }
 
-  // Between-key seeks land on next higher.
-  RTF_ASSERT(iter.find_by_secondary_key(50));
+  // Between-composite seeks: (ts=1000, sk=50) is between frame 0 (1000,1)
+  // and frame 1 (1001,100). Next higher composite is frame 1.
+  RTF_ASSERT(iter.find(1000, 50));
   RTF_ASSERT(iter->secondary_key == 100);
-  RTF_ASSERT(iter.find_by_secondary_key(99999));
-  RTF_ASSERT(iter->secondary_key == 1000000);
-  RTF_ASSERT(iter.find_by_secondary_key(999999999999LL));
-  RTF_ASSERT(iter->secondary_key == 1000000000000LL);
 
-  // Below the smallest → first.
-  RTF_ASSERT(iter.find_by_secondary_key(0));
+  // (ts=1003, sk=999999): frame 3 is (1003, 1000000), so lower_bound is
+  // frame 3.
+  RTF_ASSERT(iter.find(1003, 999999));
+  RTF_ASSERT(iter->secondary_key == 1000000);
+
+  // Below the smallest composite → first frame.
+  RTF_ASSERT(iter.find(0));
   RTF_ASSERT(iter->secondary_key == 1);
 
-  // Above the largest → invalid.
-  RTF_ASSERT(!iter.find_by_secondary_key(9999999999999999LL));
+  // Above the largest composite → invalid.
+  RTF_ASSERT(!iter.find(99999, 9999999999999999LL));
   RTF_ASSERT(!iter.valid());
 }
 
 // Secondary keys are int64, signed. Negative keys and values close to
 // INT64_MAX must work. INT64_MIN is reserved as the "unset" sentinel and is
-// implicitly off-limits for keyed streams.
+// off-limits as a real key.
 void test_nanots::test_nanots_secondary_key_extreme_values() {
   nanots_writer db("nanots_test_4mb.nts", false);
 
-  // Strictly increasing sequence of "interesting" int64 values.
+  // Each frame gets a unique timestamp AND a wildly-varying sec_key. The
+  // composite is strictly increasing because ts is.
   std::vector<int64_t> keys = {
-      INT64_MIN + 1,        // smallest legal key (INT64_MIN is the sentinel)
+      INT64_MIN + 1,        // smallest legal sec_key
       -1000000000000LL,
       -1,
       0,
@@ -2696,29 +2627,27 @@ void test_nanots::test_nanots_secondary_key_extreme_values() {
   }
 
   nanots_iterator iter("nanots_test_4mb.nts", "sk_extreme");
-  RTF_ASSERT(iter.has_secondary_key());
 
-  // Round-trip each value.
+  // Round-trip each composite.
   for (size_t i = 0; i < keys.size(); i++) {
-    RTF_ASSERT(iter.find_by_secondary_key(keys[i]));
+    int64_t ts = 1000 + (int64_t)i;
+    RTF_ASSERT(iter.find(ts, keys[i]));
     RTF_ASSERT(iter->secondary_key == keys[i]);
+    RTF_ASSERT(iter->timestamp == ts);
   }
 
-  // Boundary: searching for INT64_MIN (= sentinel) on a keyed stream should
-  // land on the smallest real key (INT64_MIN + 1).
-  RTF_ASSERT(iter.find_by_secondary_key(INT64_MIN));
+  // find(ts) with no sec_key argument defaults to UNSET (= INT64_MIN). For
+  // frame 0 at ts=1000, the composite is (1000, INT64_MIN+1); lower_bound
+  // for (1000, INT64_MIN) finds frame 0.
+  RTF_ASSERT(iter.find(1000));
   RTF_ASSERT(iter->secondary_key == INT64_MIN + 1);
 
-  // Going below INT64_MIN + 1 lands on the first real key (already the
-  // smallest, but exercise the lower-bound path).
-  RTF_ASSERT(iter.find_by_secondary_key(INT64_MIN + 1));
-  RTF_ASSERT(iter->secondary_key == INT64_MIN + 1);
-  // Step backwards from there → invalid.
+  // Backward from first frame → invalid.
   --iter;
   RTF_ASSERT(!iter.valid());
 
-  // Step forward from INT64_MAX (the last frame) → invalid.
-  RTF_ASSERT(iter.find_by_secondary_key(INT64_MAX));
+  // Forward from last frame → invalid.
+  RTF_ASSERT(iter.find(1007, INT64_MAX));
   ++iter;
   RTF_ASSERT(!iter.valid());
 }
@@ -2765,4 +2694,96 @@ void test_nanots::test_nanots_secondary_key_reader_callback() {
   for (auto sk : seen_unkeyed) {
     RTF_ASSERT(sk == NANOTS_SEC_KEY_UNSET);
   }
+}
+
+// Composite semantics: timestamps may repeat as long as sec_key strictly
+// increases within the repeat. Matches the financial-data scenario where
+// the exchange-supplied timestamp isn't unique but a sequence number is.
+void test_nanots::test_nanots_composite_duplicate_timestamps() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+
+  {
+    auto wctx = db.create_write_context("dup_ts", "");
+    // 3 frames at ts=1000 with strictly-increasing sec_keys, then a few at
+    // ts=2000 with their own monotonic sec_keys.
+    db.write(wctx, (uint8_t*)"a", 1, 0, 1000, /*sk=*/1);
+    db.write(wctx, (uint8_t*)"b", 1, 0, 1000, /*sk=*/2);
+    db.write(wctx, (uint8_t*)"c", 1, 0, 1000, /*sk=*/3);
+    db.write(wctx, (uint8_t*)"d", 1, 0, 2000, /*sk=*/10);
+    db.write(wctx, (uint8_t*)"e", 1, 0, 2000, /*sk=*/20);
+  }
+
+  // Iterate and verify all 5 frames come back in composite order.
+  nanots_iterator iter("nanots_test_4mb.nts", "dup_ts");
+  struct expected { int64_t ts; int64_t sk; char ch; };
+  std::vector<expected> want = {
+      {1000, 1, 'a'}, {1000, 2, 'b'}, {1000, 3, 'c'},
+      {2000, 10, 'd'}, {2000, 20, 'e'},
+  };
+  size_t i = 0;
+  while (iter.valid()) {
+    RTF_ASSERT(i < want.size());
+    RTF_ASSERT(iter->timestamp == want[i].ts);
+    RTF_ASSERT(iter->secondary_key == want[i].sk);
+    RTF_ASSERT(iter->size == 1);
+    RTF_ASSERT(*iter->data == (uint8_t)want[i].ch);
+    ++iter;
+    i++;
+  }
+  RTF_ASSERT(i == 5);
+
+  // Composite find lands exactly: (1000, 2) → frame 'b'.
+  RTF_ASSERT(iter.find(1000, 2));
+  RTF_ASSERT(*iter->data == 'b');
+
+  // Within a ts run, find() with default sec_key lands on the first of the
+  // run — frame 'a' for ts=1000.
+  RTF_ASSERT(iter.find(1000));
+  RTF_ASSERT(*iter->data == 'a');
+  RTF_ASSERT(iter->secondary_key == 1);
+}
+
+// find(ts) with default sec_key (=UNSET=INT64_MIN) lands on the first frame
+// at that timestamp regardless of sec_key, because UNSET is the smallest
+// possible sec_key in lex order.
+void test_nanots::test_nanots_composite_find_lands_on_first_at_ts() {
+  nanots_writer db("nanots_test_4mb.nts", false);
+  {
+    auto wctx = db.create_write_context("first_at_ts", "");
+    db.write(wctx, (uint8_t*)"x", 1, 0, 100, /*sk=*/-50);
+    db.write(wctx, (uint8_t*)"y", 1, 0, 100, /*sk=*/0);
+    db.write(wctx, (uint8_t*)"z", 1, 0, 100, /*sk=*/50);
+    db.write(wctx, (uint8_t*)"q", 1, 0, 200, /*sk=*/-100);
+  }
+
+  nanots_iterator iter("nanots_test_4mb.nts", "first_at_ts");
+
+  // find(100) lands on the first frame at ts=100 (which has the smallest
+  // sk=-50).
+  RTF_ASSERT(iter.find(100));
+  RTF_ASSERT(iter->timestamp == 100);
+  RTF_ASSERT(iter->secondary_key == -50);
+
+  // find(150) — no frame at ts=150 — lands on first frame with ts >= 150.
+  RTF_ASSERT(iter.find(150));
+  RTF_ASSERT(iter->timestamp == 200);
+  RTF_ASSERT(iter->secondary_key == -100);
+
+  // find(100, -50) is the same as find(100) here: exact match on the first
+  // frame.
+  RTF_ASSERT(iter.find(100, -50));
+  RTF_ASSERT(iter->secondary_key == -50);
+
+  // find(100, 0) lands on the middle frame.
+  RTF_ASSERT(iter.find(100, 0));
+  RTF_ASSERT(iter->secondary_key == 0);
+
+  // find(100, 1) lands on the next-greater composite — (100, 50).
+  RTF_ASSERT(iter.find(100, 1));
+  RTF_ASSERT(iter->secondary_key == 50);
+
+  // find(100, 51) skips past the ts=100 run entirely to (200, -100).
+  RTF_ASSERT(iter.find(100, 51));
+  RTF_ASSERT(iter->timestamp == 200);
+  RTF_ASSERT(iter->secondary_key == -100);
 }

--- a/ut/source/test_nanots_c_api.cpp
+++ b/ut/source/test_nanots_c_api.cpp
@@ -193,7 +193,7 @@ void test_nanots_c_api::test_c_api_iterator_functionality() {
   }
 
   // Test find functionality
-  nanots_ec_t result = nanots_iterator_find(iterator, 1200);
+  nanots_ec_t result = nanots_iterator_find(iterator, 1200, NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
   RTF_ASSERT(nanots_iterator_valid(iterator) == 1);
 
@@ -270,7 +270,7 @@ void test_nanots_c_api::test_c_api_error_handling() {
              NANOTS_EC_INVALID_ARGUMENT);
   RTF_ASSERT(nanots_iterator_next(nullptr) == NANOTS_EC_INVALID_ARGUMENT);
   RTF_ASSERT(nanots_iterator_prev(nullptr) == NANOTS_EC_INVALID_ARGUMENT);
-  RTF_ASSERT(nanots_iterator_find(nullptr, 1000) == NANOTS_EC_INVALID_ARGUMENT);
+  RTF_ASSERT(nanots_iterator_find(nullptr, 1000, NANOTS_SEC_KEY_UNSET) == NANOTS_EC_INVALID_ARGUMENT);
   RTF_ASSERT(nanots_iterator_reset(nullptr) == NANOTS_EC_INVALID_ARGUMENT);
 
   // Test null pointer parameters

--- a/ut/source/test_nanots_c_api.cpp
+++ b/ut/source/test_nanots_c_api.cpp
@@ -90,7 +90,7 @@ void test_nanots_c_api::test_c_api_basic_write_read() {
   // Read data back - use a smaller end timestamp to avoid potential UINT64_MAX
   // binding issues
   result =
-      nanots_reader_read(reader, "test_stream", 0, 10000, callback, &cb_data);
+      nanots_reader_read(reader, "test_stream", 0, NANOTS_SEC_KEY_UNSET, 10000, INT64_MAX, callback, &cb_data);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   // Verify read data
@@ -247,7 +247,7 @@ void test_nanots_c_api::test_c_api_contiguous_segments() {
   size_t count = 0;
 
   nanots_ec_t result = nanots_reader_query_contiguous_segments(
-      reader, "segment_stream", 0, 10000, &segments, &count);
+      reader, "segment_stream", 0, NANOTS_SEC_KEY_UNSET, 10000, INT64_MAX, &segments, &count);
   RTF_ASSERT(result == NANOTS_EC_OK);
   RTF_ASSERT(count > 0);
   RTF_ASSERT(segments != nullptr);
@@ -276,7 +276,7 @@ void test_nanots_c_api::test_c_api_error_handling() {
   // Test null pointer parameters
   nanots_contiguous_segment_t* segments = nullptr;
   size_t count = 0;
-  RTF_ASSERT(nanots_reader_query_contiguous_segments(nullptr, "test", 0, 100,
+  RTF_ASSERT(nanots_reader_query_contiguous_segments(nullptr, "test", 0, NANOTS_SEC_KEY_UNSET, 100, INT64_MAX,
                                                      &segments, &count) ==
              NANOTS_EC_INVALID_ARGUMENT);
 
@@ -351,7 +351,7 @@ void test_nanots_c_api::test_c_api_multiple_streams() {
   };
 
   result =
-      nanots_reader_read(reader, "stream1", 0, 10000, callback1, &stream1_data);
+      nanots_reader_read(reader, "stream1", 0, NANOTS_SEC_KEY_UNSET, 10000, INT64_MAX, callback1, &stream1_data);
   RTF_ASSERT(result == NANOTS_EC_OK);
   RTF_ASSERT(stream1_data.size() == 1);
   RTF_ASSERT(stream1_data[0] == "Stream 1 data");
@@ -359,7 +359,7 @@ void test_nanots_c_api::test_c_api_multiple_streams() {
   // Test stream2
   vector<string> stream2_data;
   result =
-      nanots_reader_read(reader, "stream2", 0, 10000, callback1, &stream2_data);
+      nanots_reader_read(reader, "stream2", 0, NANOTS_SEC_KEY_UNSET, 10000, INT64_MAX, callback1, &stream2_data);
   RTF_ASSERT(result == NANOTS_EC_OK);
   RTF_ASSERT(stream2_data.size() == 1);
   RTF_ASSERT(stream2_data[0] == "Stream 2 data");
@@ -426,7 +426,7 @@ void test_nanots_c_api::test_c_api_query_stream_tags() {
   RTF_ASSERT(reader != nullptr);
 
   // Test 1: Query time range that includes all streams (0-3000)
-  result = nanots_reader_query_stream_tags_start(reader, 0, 3000);
+  result = nanots_reader_query_stream_tags_start(reader, 0, NANOTS_SEC_KEY_UNSET, 3000, INT64_MAX);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   vector<string> all_streams;
@@ -441,7 +441,7 @@ void test_nanots_c_api::test_c_api_query_stream_tags() {
   RTF_ASSERT(find(all_streams.begin(), all_streams.end(), "stream_gamma") != all_streams.end());
 
   // Test 2: Query time range that includes only stream_alpha and stream_beta (1000-1800)
-  result = nanots_reader_query_stream_tags_start(reader, 1000, 1800);
+  result = nanots_reader_query_stream_tags_start(reader, 1000, NANOTS_SEC_KEY_UNSET, 1800, INT64_MAX);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   vector<string> partial_streams;
@@ -455,7 +455,7 @@ void test_nanots_c_api::test_c_api_query_stream_tags() {
   RTF_ASSERT(find(partial_streams.begin(), partial_streams.end(), "stream_gamma") == partial_streams.end());
 
   // Test 3: Query time range that includes no streams (3000-4000)
-  result = nanots_reader_query_stream_tags_start(reader, 3000, 4000);
+  result = nanots_reader_query_stream_tags_start(reader, 3000, NANOTS_SEC_KEY_UNSET, 4000, INT64_MAX);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   vector<string> no_streams;
@@ -470,7 +470,7 @@ void test_nanots_c_api::test_c_api_query_stream_tags() {
   RTF_ASSERT(stream_tag == nullptr);
 
   // Test 5: Test error handling with invalid reader
-  result = nanots_reader_query_stream_tags_start(nullptr, 0, 1000);
+  result = nanots_reader_query_stream_tags_start(nullptr, 0, NANOTS_SEC_KEY_UNSET, 1000, INT64_MAX);
   RTF_ASSERT(result == NANOTS_EC_INVALID_ARGUMENT);
   
   stream_tag = nanots_reader_query_stream_tags_next(nullptr);

--- a/ut/source/test_nanots_c_api.cpp
+++ b/ut/source/test_nanots_c_api.cpp
@@ -45,15 +45,18 @@ void test_nanots_c_api::test_c_api_basic_write_read() {
   const char* data3 = "Third frame with more data";
 
   nanots_ec_t result = nanots_writer_write(
-      writer, context, (const uint8_t*)data1, strlen(data1), 1000, 0x01);
+      writer, context, (const uint8_t*)data1, strlen(data1), 0x01, 1000,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   result = nanots_writer_write(writer, context, (const uint8_t*)data2,
-                               strlen(data2), 2000, 0x02);
+                               strlen(data2), 0x02, 2000,
+                               NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   result = nanots_writer_write(writer, context, (const uint8_t*)data3,
-                               strlen(data3), 3000, 0x03);
+                               strlen(data3), 0x03, 3000,
+                               NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   // Clean up writer resources
@@ -65,15 +68,16 @@ void test_nanots_c_api::test_c_api_basic_write_read() {
   // Callback data collection
   struct callback_data {
     vector<string> frames;
-    vector<uint8_t> flags;
+    vector<uint32_t> flags;
     vector<int64_t> timestamps;
     vector<int64_t> block_sequences;
     vector<string> metadata_list;
   } cb_data;
 
   // Define callback function
-  auto callback = [](const uint8_t* data, size_t size, uint8_t flags,
-                     int64_t timestamp, int64_t block_sequence, const char* metadata,
+  auto callback = [](const uint8_t* data, size_t size, uint32_t flags,
+                     int64_t timestamp, int64_t /*secondary_key*/,
+                     int64_t block_sequence, const char* metadata,
                      void* user_data) {
     callback_data* cb = static_cast<callback_data*>(user_data);
     cb->frames.emplace_back(reinterpret_cast<const char*>(data), size);
@@ -122,7 +126,8 @@ void test_nanots_c_api::test_c_api_iterator_functionality() {
     string data = "Frame " + to_string(i);
     nanots_ec_t result =
         nanots_writer_write(writer, context, (const uint8_t*)data.c_str(),
-                            data.size(), 1000 + i * 100, (uint8_t)i);
+                            data.size(), (uint32_t)i, 1000 + i * 100,
+                            NANOTS_SEC_KEY_UNSET);
     RTF_ASSERT(result == NANOTS_EC_OK);
   }
 
@@ -226,7 +231,8 @@ void test_nanots_c_api::test_c_api_contiguous_segments() {
     string data = "Segment data " + to_string(i);
     nanots_ec_t result =
         nanots_writer_write(writer, context, (const uint8_t*)data.c_str(),
-                            data.size(), 1000 + i * 100, 0);
+                            data.size(), 0, 1000 + i * 100,
+                            NANOTS_SEC_KEY_UNSET);
     RTF_ASSERT(result == NANOTS_EC_OK);
   }
 
@@ -286,12 +292,14 @@ void test_nanots_c_api::test_c_api_error_handling() {
 
   // Write first frame
   nanots_ec_t result = nanots_writer_write(
-      writer, context, (const uint8_t*)data, strlen(data), 2000, 0);
+      writer, context, (const uint8_t*)data, strlen(data), 0, 2000,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   // Try to write frame with earlier timestamp (should fail)
   result = nanots_writer_write(writer, context, (const uint8_t*)data,
-                               strlen(data), 1000, 0);
+                               strlen(data), 0, 1000,
+                               NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_NON_MONOTONIC_TIMESTAMP);
 
   nanots_write_context_destroy(context);
@@ -315,11 +323,13 @@ void test_nanots_c_api::test_c_api_multiple_streams() {
   const char* data2 = "Stream 2 data";
 
   nanots_ec_t result = nanots_writer_write(
-      writer, context1, (const uint8_t*)data1, strlen(data1), 1000, 1);
+      writer, context1, (const uint8_t*)data1, strlen(data1), 1, 1000,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   result = nanots_writer_write(writer, context2, (const uint8_t*)data2,
-                               strlen(data2), 1100, 2);
+                               strlen(data2), 2, 1100,
+                               NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   nanots_write_context_destroy(context1);
@@ -332,8 +342,9 @@ void test_nanots_c_api::test_c_api_multiple_streams() {
 
   // Test stream1
   vector<string> stream1_data;
-  auto callback1 = [](const uint8_t* data, size_t size, uint8_t flags,
-                      int64_t timestamp, int64_t block_sequence, const char* metadata,
+  auto callback1 = [](const uint8_t* data, size_t size, uint32_t flags,
+                      int64_t timestamp, int64_t /*secondary_key*/,
+                      int64_t block_sequence, const char* metadata,
                       void* user_data) {
     vector<string>* frames = static_cast<vector<string>*>(user_data);
     frames->emplace_back(reinterpret_cast<const char*>(data), size);
@@ -377,26 +388,32 @@ void test_nanots_c_api::test_c_api_query_stream_tags() {
   
   // stream_alpha: 1000-1200
   nanots_ec_t result = nanots_writer_write(
-      writer, context1, (const uint8_t*)data, strlen(data), 1000, 0);
+      writer, context1, (const uint8_t*)data, strlen(data), 0, 1000,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
   result = nanots_writer_write(
-      writer, context1, (const uint8_t*)data, strlen(data), 1200, 0);
+      writer, context1, (const uint8_t*)data, strlen(data), 0, 1200,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   // stream_beta: 1500-1700
   result = nanots_writer_write(
-      writer, context2, (const uint8_t*)data, strlen(data), 1500, 0);
+      writer, context2, (const uint8_t*)data, strlen(data), 0, 1500,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
   result = nanots_writer_write(
-      writer, context2, (const uint8_t*)data, strlen(data), 1700, 0);
+      writer, context2, (const uint8_t*)data, strlen(data), 0, 1700,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   // stream_gamma: 2000-2200
   result = nanots_writer_write(
-      writer, context3, (const uint8_t*)data, strlen(data), 2000, 0);
+      writer, context3, (const uint8_t*)data, strlen(data), 0, 2000,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
   result = nanots_writer_write(
-      writer, context3, (const uint8_t*)data, strlen(data), 2200, 0);
+      writer, context3, (const uint8_t*)data, strlen(data), 0, 2200,
+      NANOTS_SEC_KEY_UNSET);
   RTF_ASSERT(result == NANOTS_EC_OK);
 
   nanots_write_context_destroy(context1);

--- a/ut/source/test_nanots_ebr.cpp
+++ b/ut/source/test_nanots_ebr.cpp
@@ -78,7 +78,7 @@ void test_nanots_ebr::test_basic_auto_reclaim_no_readers() {
     int64_t ts = 1000 + i * 100;
     _fill_payload_with_ts(payload, ts);
     RTF_ASSERT_NO_THROW(
-        writer.write(wctx, payload.data(), payload.size(), ts, 0));
+        writer.write(wctx, payload.data(), payload.size(), 0, ts));
   }
   // If we got here, auto_reclaim worked. With no readers, every retire
   // should clear limbo immediately and migrate to ready.
@@ -101,7 +101,7 @@ void test_nanots_ebr::test_reader_pins_then_releases() {
     for (int i = 0; i < 32; ++i) {
       int64_t ts = 1000 + i * 100;
       _fill_payload_with_ts(payload, ts);
-      writer.write(wctx, payload.data(), payload.size(), ts, 0);
+      writer.write(wctx, payload.data(), payload.size(), 0, ts);
     }
   }
 
@@ -165,7 +165,7 @@ void test_nanots_ebr::test_dead_heartbeat_does_not_pin() {
     auto wctx = writer.create_write_context("stream_a", "meta");
     std::vector<uint8_t> payload(256, 0xEF);
     for (int i = 0; i < 8; ++i) {
-      writer.write(wctx, payload.data(), payload.size(), 1000 + i * 100, 0);
+      writer.write(wctx, payload.data(), payload.size(), 0, 1000 + i * 100);
     }
   }
 
@@ -204,7 +204,7 @@ void test_nanots_ebr::test_iterator_op_advances_epoch() {
     auto wctx = writer.create_write_context("stream_a", "meta");
     std::vector<uint8_t> payload(256, 0x11);
     for (int i = 0; i < 8; ++i) {
-      writer.write(wctx, payload.data(), payload.size(), 1000 + i * 100, 0);
+      writer.write(wctx, payload.data(), payload.size(), 0, 1000 + i * 100);
     }
   }
 
@@ -260,7 +260,7 @@ void test_nanots_ebr::test_stress_concurrent_writer_readers() {
     while (!stop.load(std::memory_order_relaxed)) {
       _fill_payload_with_ts(payload, ts);
       try {
-        writer.write(wctx, payload.data(), payload.size(), ts, 0);
+        writer.write(wctx, payload.data(), payload.size(), 0, ts);
         frames_written.fetch_add(1, std::memory_order_relaxed);
         max_written_ts.store(ts, std::memory_order_relaxed);
         ts += 100;
@@ -287,8 +287,9 @@ void test_nanots_ebr::test_stress_concurrent_writer_readers() {
         int64_t lo = hi > 100000 ? hi - 100000 : 1000;
         try {
           reader.read("stream_a", lo, hi,
-              [&](const uint8_t* data, size_t size, uint8_t /*flags*/,
-                  int64_t ts, int64_t /*block_seq*/,
+              [&](const uint8_t* data, size_t size, uint32_t /*flags*/,
+                  int64_t ts, int64_t /*sec_key*/,
+                  int64_t /*block_seq*/,
                   const std::string& /*meta*/) {
                 if (!_verify_payload_matches_ts(data, size, ts)) {
                   integrity_failures.fetch_add(1, std::memory_order_relaxed);
@@ -344,7 +345,7 @@ void test_nanots_ebr::test_ts_index_refresh_finds_new_blocks() {
     for (int i = 0; i < 32; ++i) {
       int64_t ts = 1000 + i * 100;
       _fill_payload_with_ts(payload, ts);
-      writer.write(wctx, payload.data(), payload.size(), ts, 0);
+      writer.write(wctx, payload.data(), payload.size(), 0, ts);
     }
   }
 
@@ -361,7 +362,7 @@ void test_nanots_ebr::test_ts_index_refresh_finds_new_blocks() {
     for (int i = 32; i < 64; ++i) {
       int64_t ts = 1000 + i * 100;
       _fill_payload_with_ts(payload, ts);
-      writer.write(wctx, payload.data(), payload.size(), ts, 0);
+      writer.write(wctx, payload.data(), payload.size(), 0, ts);
     }
   }
 

--- a/ut/source/test_nanots_ebr.cpp
+++ b/ut/source/test_nanots_ebr.cpp
@@ -286,7 +286,7 @@ void test_nanots_ebr::test_stress_concurrent_writer_readers() {
         }
         int64_t lo = hi > 100000 ? hi - 100000 : 1000;
         try {
-          reader.read("stream_a", lo, hi,
+          reader.read("stream_a", lo, NANOTS_SEC_KEY_UNSET, hi, INT64_MAX,
               [&](const uint8_t* data, size_t size, uint32_t /*flags*/,
                   int64_t ts, int64_t /*sec_key*/,
                   int64_t /*block_seq*/,


### PR DESCRIPTION
This pull request introduces a major upgrade to the NanoTS time-series database, focusing on a new on-disk format (v2) and support for composite (timestamp, secondary_key) ordering. The changes are reflected in both the codebase (`amalgamated_src/nanots.h`) and documentation (`README.md`), enabling advanced use cases where timestamps may not be unique. The API is expanded to support composite-key operations throughout writing, reading, seeking, and deletion. The new format is not backward-compatible with v1.
