### PR TITLE
fix: nanots_writer::write() crashes on exact-max-size frames

### DIFF
--- a/nanots.cpp
+++ b/nanots.cpp
@@ -974,6 +974,7 @@ void nanots_writer::write(write_context& wctx,
   uint32_t padded_frame_size = (total_frame_size + 7) & ~7;  // Round up to multiple of 8
 
   uint64_t new_block_ofs = (uint64_t)(_block_size - padded_frame_size);
+  bool fits = (new_block_ofs >= index_end);
 
   if (n_valid_indexes > 0) {
     uint8_t* last_index_p = block_p + BLOCK_HEADER_SIZE +
@@ -981,13 +982,15 @@ void nanots_writer::write(write_context& wctx,
     uint64_t last_frame_offset = *(uint64_t*)(last_index_p + INDEX_ENTRY_OFFSET_OFFSET);
     if (last_frame_offset >= padded_frame_size) {
       uint64_t candidate_ofs = last_frame_offset - padded_frame_size;
-      new_block_ofs = (candidate_ofs >= index_end) ? candidate_ofs : index_end;
+      fits = (candidate_ofs >= index_end);
+      new_block_ofs = fits ? candidate_ofs : index_end;
     } else {
+      fits = false;
       new_block_ofs = index_end;  // Force rollover to new block
     }
   }
 
-  if (index_end >= new_block_ofs) {
+  if (!fits) {
     nts_sqlite_conn conn(_database_name(_file_name), true, true);
 
     wctx.mm.flush(wctx.mm.map(), _block_size, true);


### PR DESCRIPTION
## Problem

Writing a frame whose padded size exactly fills the remaining space in a block throws `std::bad_optional_access` from `nanots_writer::write()`.

The fit check `if (index_end >= new_block_ofs)` reuses `index_end` for two different purposes that happen to collide:

- On the **first write into an empty block** (`n_valid_indexes == 0`), `new_block_ofs == index_end` legitimately means "this frame fits exactly, starting right where the index area ends."
- On a **subsequent write** (`n_valid_indexes > 0`), when the previous frame doesn't leave room for the new one, the code falls back to `new_block_ofs = index_end` purely as a sentinel meaning "no room, must roll over to a new block."

Because both situations produce `index_end == new_block_ofs`, the single comparison `index_end >= new_block_ofs` can't tell them apart, and the legitimate "fits exactly" case gets misclassified as "no room." That sends the first write down the finalize-and-retry path, which calls `wctx.last_timestamp.value()` — but `last_timestamp` is still `std::nullopt` since no write has succeeded yet, so it throws.

## Fix

Track a `fits` boolean explicitly at the point each `new_block_ofs` candidate is actually computed, instead of re-deriving "did it fit" afterward from a comparison that means different things in the two code paths:

```cpp
uint64_t new_block_ofs = (uint64_t)(_block_size - padded_frame_size);
bool fits = (new_block_ofs >= index_end);

if (n_valid_indexes > 0) {
  ...
  if (last_frame_offset >= padded_frame_size) {
    uint64_t candidate_ofs = last_frame_offset - padded_frame_size;
    fits = (candidate_ofs >= index_end);
    new_block_ofs = fits ? candidate_ofs : index_end;
  } else {
    fits = false;
    new_block_ofs = index_end;  // Force rollover to new block
  }
}

if (!fits) {
  ...
```

Note a simpler-looking `>=` → `>` change to the original check is *not* equivalent and is unsafe: it would also flip the meaning of the `new_block_ofs = index_end` sentinel used to force a rollover when there truly isn't room, causing the write to proceed at a colliding offset instead of rolling over — silent data corruption rather than a clean exception. The `fits` boolean avoids that by not overloading one value for two meanings.

## Testing

Built `nanots.cpp`/`utils.cpp`/`sqlite3.c` standalone and reproduced against both the unpatched and patched source:

- Writing exactly `block_size - BLOCK_HEADER_SIZE - INDEX_ENTRY_SIZE - FRAME_HEADER_SIZE` bytes (the library's documented max frame size) as the first write on a fresh `write_context`:
  - Unpatched: throws `std::bad_optional_access`.
  - Patched: succeeds.
- Followed by a second, small write on the same context:
  - Patched: correctly rolls over into a new block. Verified both via `nanots_reader::read()` (both frames read back with correct size/timestamp/content) and via a raw on-disk block-header dump (each frame lands in its own block, no overlap).
- Ran 500 sequential ordinary-sized writes (forcing several genuine multi-block rollovers under normal, non-boundary conditions) through the patched build — all round-trip correctly, confirming no behavior change for regular usage.
- The pre-existing `NANOTS_EC_ROW_SIZE_TOO_BIG` guard for frames larger than the max is untouched by this change and still rejects oversized frames.